### PR TITLE
Import du type de position et du nom de lieu dit (API de gestion)

### DIFF
--- a/lib/import/sources/ign-api-gestion.js
+++ b/lib/import/sources/ign-api-gestion.js
@@ -63,6 +63,7 @@ async function importData(part) {
         numero: parseNumero(row.numero),
         suffixe: row.suffixe,
         nomVoie: row.nom_voie,
+        lieuDitComplementNom: row.nom_complementaire || undefined,
         codePostal: row.code_postal,
         codeCommune: row.code_insee,
         nomCommune: row.nom_commune

--- a/lib/import/sources/ign-api-gestion.js
+++ b/lib/import/sources/ign-api-gestion.js
@@ -61,7 +61,7 @@ async function importData(part) {
         idAdresse: row.id_ban_adresse,
         anciensIdAdresse: row.id_ban_adresse in idIgnMapping ? idIgnMapping[row.id_ban_adresse].map(r => r.ign).sort() : [],
         numero: parseNumero(row.numero),
-        suffixe: row.suffixe,
+        suffixe: row.suffixe || undefined,
         nomVoie: row.nom_voie,
         lieuDitComplementNom: row.nom_complementaire || undefined,
         codePostal: row.code_postal,

--- a/lib/import/sources/ign-api-gestion.js
+++ b/lib/import/sources/ign-api-gestion.js
@@ -9,6 +9,24 @@ function parseCoords(str, precision) {
   return Math.round(number * exp) / exp
 }
 
+const IGN_POSITION_TYPE_MAPPING = {
+  postal: 'délivrance postale',
+  entrance: 'entrée',
+  building: 'bâtiment',
+  staircase: 'cage d’escalier',
+  unit: 'logement',
+  parcel: 'parcelle',
+  segment: 'segment',
+  utility: 'service technique',
+  area: 'segment'
+}
+
+function getPositionType(originalType) {
+  if (originalType in IGN_POSITION_TYPE_MAPPING) {
+    return IGN_POSITION_TYPE_MAPPING[originalType]
+  }
+}
+
 async function importData(part) {
   const resourcesDefinition = [
     {
@@ -52,7 +70,7 @@ async function importData(part) {
 
       if (row.id_ban_position) {
         adresse.idPosition = row.id_ban_position
-        adresse.typePosition = row.typ_loc
+        adresse.positionType = getPositionType(row.typ_loc)
         adresse.sourcePosition = row.source
         adresse.dateMAJPosition = row.date_der_maj
         adresse.position = {


### PR DESCRIPTION
Le type de position d'une adresse issue de la source API de gestion (`type_loc`) était importé de façon incorrecte.
C'est désormais corrigé, et le type est désormais converti en type "BAL".

L'attribut `lieuDitComplementNom` est quand à lui désormais importé à partir du champ `nom_complementaire` du format d'export API de gestion.