### PR TITLE
Ajoute la prise en compte du `.env` pour `server.js`

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env
+require('dotenv').config()
+
 const express = require('express')
 const morgan = require('morgan')
 const cors = require('cors')


### PR DESCRIPTION
Cette PR corrige la prise en compte du fichier `.env` qui a été supprimée.