### PR TITLE
Correction BAL_URL_PATTERN

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,4 +14,4 @@ COMMUNES=
 MAX_CONCURRENT_WORKERS=1
 
 DATAGOUV_API_KEY=
-BAL_URL_PATTERN=https://adresse.data.gouv.fr/data/adresses-locales/latest/csv/adresses-locales-<dep>.csv.gz
+BAL_URL_PATTERN=https://adresse.data.gouv.fr/data/adresses-locales/latest/csv/adresses-locales-{dep}.csv.gz

--- a/lib/import/sources/bal.js
+++ b/lib/import/sources/bal.js
@@ -48,7 +48,7 @@ function prepareData(item) {
 function createUrl(part) {
   const BAL_URL_PATTERN = process.env.BAL_URL_PATTERN || 'https://adresse.data.gouv.fr/data/adresses-locales/latest/csv/adresses-locales-{dep}.csv.gz'
   return BAL_URL_PATTERN
-    .replace('<dep>', part)
+    .replace('{dep}', part)
 }
 
 async function importData(part) {


### PR DESCRIPTION
Il y avait une erreur de syntaxe.
J'ai convergé vers `{dep}` qui est du coup cohérent avec le RIL.