### PR TITLE
Correction parsing adresses du cadastre

### DIFF
--- a/lib/import/sources/cadastre.js
+++ b/lib/import/sources/cadastre.js
@@ -25,11 +25,17 @@ function prepareData(addr, enc, next) {
     return next()
   }
 
+  const numero = Number.parseInt(addr.numero, 10)
+
+  if (!Number.isInteger(numero) || numero <= 0) {
+    return next()
+  }
+
   const adresse = {
     dataSource: 'cadastre',
     source: 'cadastre',
     idAdresse: addr.id,
-    numero: addr.numero,
+    numero,
     suffixe: addr.suffixe,
     nomVoie: addr.nomVoie,
     codeCommune: normalizeCodeCommune(addr.codeCommune),


### PR DESCRIPTION
Le type fourni est une `String`
Le type souhaité est un `Integer`