### PR TITLE
Modification pour l'export BAL CSV départemental vs communal

### DIFF
--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -4,7 +4,7 @@ const {snakeCase, mapKeys} = require('lodash')
 const {getCommune, getCommuneData, getPopulatedVoie, getPopulatedNumero, getPopulatedCommune, getAdressesFeatures, getToponymesFeatures, getCommunesSummary} = require('../models/commune')
 const Metric = require('../models/metric')
 const {prepareAdresses: prepareAdressesLegacy, prepareLieuxDits} = require('../formatters/csv-legacy')
-const {prepareAdresses: prepareAdressesBal} = require('../formatters/csv-bal')
+const {prepareAdresses: prepareAdressesBal, extractHeaders} = require('../formatters/csv-bal')
 const w = require('../util/w')
 const serveMvt = require('../util/serve-mvt')
 
@@ -50,7 +50,12 @@ app.get('/ban/communes/:codeCommune/download/csv-bal/adresses', w(async (req, re
   const {codeCommune} = req.params
   const {voies, numeros} = await getCommuneData(codeCommune)
   const adresses = prepareAdressesBal({voies, numeros})
-  const csvFile = Papa.unparse(adresses, {delimiter: ';'})
+  const headers = extractHeaders(adresses)
+  const csvFile = Papa.unparse(adresses, {
+    delimiter: ';',
+    header: true,
+    columns: headers
+  })
 
   res
     .attachment(`adresses-${codeCommune}.csv`)

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -49,7 +49,7 @@ app.get('/ban/communes/:codeCommune/download/csv-legacy/lieux-dits', w(async (re
 app.get('/ban/communes/:codeCommune/download/csv-bal/adresses', w(async (req, res) => {
   const {codeCommune} = req.params
   const {voies, numeros} = await getCommuneData(codeCommune)
-  const adresses = prepareAdressesBal({voies, numeros})
+  const adresses = prepareAdressesBal({voies, numeros}, true)
   const headers = extractHeaders(adresses)
   const csvFile = Papa.unparse(adresses, {
     delimiter: ';',

--- a/lib/formatters/csv-bal.js
+++ b/lib/formatters/csv-bal.js
@@ -36,7 +36,7 @@ function extractHeaders(csvRows) {
   return [...headers]
 }
 
-function buildRow(voie, numero, position) {
+function buildRow(voie, numero, position, includesAlt = false) {
   const row = {
     uid_adresse: '',
     cle_interop: numero.cleInterop,
@@ -58,17 +58,18 @@ function buildRow(voie, numero, position) {
     date_der_maj: '',
     certification_commune: numero.certifie ? '1' : '0'
   }
+  if (includesAlt) {
+    if (voie.nomVoieAlt) {
+      Object.keys(voie.nomVoieAlt).forEach(o => {
+        row['voie_nom_' + o] = voie.nomVoieAlt[o]
+      })
+    }
 
-  if (voie.nomVoieAlt) {
-    Object.keys(voie.nomVoieAlt).forEach(o => {
-      row['voie_nom_' + o] = voie.nomVoieAlt[o]
-    })
-  }
-
-  if (numero.lieuDitComplementNomAlt) {
-    Object.keys(numero.lieuDitComplementNomAlt).forEach(o => {
-      row['lieudit_complement_nom_' + o] = numero.lieuDitComplementNomAlt[o]
-    })
+    if (numero.lieuDitComplementNomAlt) {
+      Object.keys(numero.lieuDitComplementNomAlt).forEach(o => {
+        row['lieudit_complement_nom_' + o] = numero.lieuDitComplementNomAlt[o]
+      })
+    }
   }
 
   if (position) {
@@ -94,7 +95,7 @@ function createFakeNumero(voie) {
   }
 }
 
-function prepareAdresses({voies, numeros}) {
+function prepareAdresses({voies, numeros}, includesAlt) {
   const numerosIndex = groupBy(numeros, 'idVoie')
   const rows = []
 
@@ -104,15 +105,15 @@ function prepareAdresses({voies, numeros}) {
     const positionsVoie = voie.positions || []
 
     if (!numerosVoie && positionsVoie.length === 0) {
-      rows.push(buildRow(voie, fakeNumero))
+      rows.push(buildRow(voie, fakeNumero, includesAlt))
     } else {
       for (const position of positionsVoie) {
-        rows.push(buildRow(voie, fakeNumero, position))
+        rows.push(buildRow(voie, fakeNumero, position, includesAlt))
       }
 
       for (const numero of numerosVoie) {
         for (const position of numero.positions) {
-          rows.push(buildRow(voie, numero, position))
+          rows.push(buildRow(voie, numero, position, includesAlt))
         }
       }
     }

--- a/lib/formatters/csv-bal.js
+++ b/lib/formatters/csv-bal.js
@@ -24,6 +24,18 @@ function beautifyOrEmpty(string) {
   return string ? beautify(string) : ''
 }
 
+function extractHeaders(csvRows) {
+  const headers = new Set()
+
+  for (const row of csvRows) {
+    for (const header of Object.keys(row)) {
+      headers.add(header)
+    }
+  }
+
+  return [...headers]
+}
+
 function buildRow(voie, numero, position) {
   const row = {
     uid_adresse: '',
@@ -45,6 +57,18 @@ function buildRow(voie, numero, position) {
     source: getSource(numero.sourcePosition) || getSource(voie.sourceNomVoie) || '',
     date_der_maj: '',
     certification_commune: numero.certifie ? '1' : '0'
+  }
+
+  if (voie.nomVoieAlt) {
+    Object.keys(voie.nomVoieAlt).forEach(o => {
+      row['voie_nom_' + o] = voie.nomVoieAlt[o]
+    })
+  }
+
+  if (numero.lieuDitComplementNomAlt) {
+    Object.keys(numero.lieuDitComplementNomAlt).forEach(o => {
+      row['lieudit_complement_nom_' + o] = numero.lieuDitComplementNomAlt[o]
+    })
   }
 
   if (position) {
@@ -97,4 +121,4 @@ function prepareAdresses({voies, numeros}) {
   return rows
 }
 
-module.exports = {prepareAdresses}
+module.exports = {prepareAdresses, extractHeaders}


### PR DESCRIPTION
Modification pour l'export bal csv, option sur prepareData pour les LR.
Par défaut on n'inclut pas les LR pour prendre en compte le fait qu'on exporte pas les LR sur les exports départementaux.