### PR TITLE
Composition à partir de l'API de dépôt

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,3 +15,5 @@ MAX_CONCURRENT_WORKERS=1
 
 DATAGOUV_API_KEY=
 BAL_URL_PATTERN=https://adresse.data.gouv.fr/data/adresses-locales/latest/csv/adresses-locales-{dep}.csv.gz
+
+API_DEPOT_URL=https://plateforme.adresse.data.gouv.fr/api-depot

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -90,6 +90,8 @@ app.get('/api/communes-summary.csv', w(async (req, res) => {
     'code_commune',
     'nom_commune',
     'population',
+    'id_revision',
+    'date_revision',
     'type_composition',
     'nb_lieux_dits',
     'nb_voies',

--- a/lib/compose/import-from-api-depot.js
+++ b/lib/compose/import-from-api-depot.js
@@ -1,0 +1,46 @@
+const {validate} = require('@ban-team/validateur-bal')
+const {getRevisionFile} = require('../util/api-depot')
+
+async function importFromApiDepot(revision) {
+  const revisionFile = await getRevisionFile(revision._id)
+  const validationResult = await validate(revisionFile, {relaxFieldsDetection: true})
+
+  if (!validationResult.parseOk) {
+    throw new Error(`Le fichier BAL récupéré n’est pas valide : ${revision._id}`)
+  }
+
+  return validationResult.rows.map(row => {
+    const adresse = {
+      dataSource: 'bal',
+      source: 'bal',
+      cleInterop: row.parsedValues.cle_interop,
+      uidAdresse: row.parsedValues.uid_adresse,
+      numero: row.parsedValues.numero,
+      suffixe: row.parsedValues.suffixe,
+      nomVoie: row.parsedValues.voie_nom,
+      lieuDitComplementNom: row.parsedValues.lieudit_complement_nom,
+      parcelles: row.parsedValues.cad_parcelles || [],
+      codeCommune: row.parsedValues.commune_insee || row.additionalValues.cle_interop.codeCommune,
+      nomCommune: row.parsedValues.commune_nom,
+      codeAncienneCommune: row.parsedValues.commune_deleguee_insee,
+      nomAncienneCommune: row.parsedValues.commune_deleguee_nom,
+      certificationCommune: row.parsedValues.certification_commune || false,
+      dateMAJ: row.parsedValues.date_der_maj,
+      nomVoieAlt: row.localizedValues.voie_nom || {},
+      lieuDitComplementNomAlt: row.localizedValues.lieudit_complement_nom || {}
+    }
+
+    if (row.parsedValues.long && row.parsedValues.lat) {
+      adresse.position = {
+        type: 'Point',
+        coordinates: [row.parsedValues.long, row.parsedValues.lat]
+      }
+
+      adresse.positionType = row.parsedValues.position
+    }
+
+    return adresse
+  })
+}
+
+module.exports = importFromApiDepot

--- a/lib/compose/index.js
+++ b/lib/compose/index.js
@@ -120,7 +120,9 @@ async function composeCommune(codeCommune) {
     nbNumerosCertifies,
     nbVoies: voies.length,
     nbLieuxDits: lieuxDits.length,
-    typeComposition: isBAL ? 'bal' : 'assemblage'
+    typeComposition: isBAL ? 'bal' : 'assemblage',
+    idRevision: currentRevision?._id,
+    dateRevision: currentRevision?.publishedAt
   }
 
   if (codeCommune in locauxAdressesIndex) {

--- a/lib/compose/index.js
+++ b/lib/compose/index.js
@@ -39,8 +39,6 @@ async function composeCommune(codeCommune) {
   const communeCOG = getCommuneCOG(codeCommune)
   const commune = await getCommune(codeCommune)
 
-  const pseudoCodeVoieGenerator = await createPseudoCodeVoieGenerator(codeCommune)
-
   if (!communeCOG) {
     throw new Error(`La commune ${codeCommune} n’existe pas.`)
   }
@@ -54,6 +52,8 @@ async function composeCommune(codeCommune) {
   }
 
   const multiSourcesData = !isBAL && await getMultiSourcesData(codeCommune)
+
+  const pseudoCodeVoieGenerator = await createPseudoCodeVoieGenerator(codeCommune)
 
   const composeVoiesOptions = {
     codeCommune,

--- a/lib/compose/index.js
+++ b/lib/compose/index.js
@@ -46,7 +46,8 @@ async function composeCommune(codeCommune) {
   const balData = await getSourceData('bal', codeCommune)
   const isBAL = balData.adresses.length > 0
 
-  if (!isBAL && commune.typeComposition === 'bal') {
+  // Contrôle à supprimer dès lors que le Moissonneur v2 sera en place
+  if (!isBAL && commune?.typeComposition === 'bal') {
     console.log(`Composition des adresses de la commune ${codeCommune} abandonnée => régression vers assemblage interdite`)
     return
   }
@@ -58,7 +59,7 @@ async function composeCommune(codeCommune) {
   const composeVoiesOptions = {
     codeCommune,
     pseudoCodeVoieGenerator,
-    forceCertification: commune.forceCertification
+    forceCertification: commune?.forceCertification
   }
 
   const composedVoies = isBAL

--- a/lib/compose/index.js
+++ b/lib/compose/index.js
@@ -10,8 +10,13 @@ const {getCommune, saveCommuneData} = require('../models/commune')
 const source = require('../models/source')
 
 const {createPseudoCodeVoieGenerator} = require('../pseudo-codes-voies')
+const {getCurrentRevision} = require('../util/api-depot')
+
 const MS = require('./strategies/multi-sources')
 const BAL = require('./strategies/bal')
+
+const prepareBalData = require('./sources/bal')
+const importFromApiDepot = require('./import-from-api-depot')
 
 const locauxAdressesIndex = keyBy(communesLocauxAdresses, 'codeCommune')
 
@@ -35,6 +40,15 @@ async function getMultiSourcesData(codeCommune) {
   })
 }
 
+async function getBalData(codeCommune, revision) {
+  if (revision) {
+    const adresses = await importFromApiDepot(revision)
+    return prepareBalData(adresses, {codeCommune})
+  }
+
+  return getSourceData('bal', codeCommune)
+}
+
 async function composeCommune(codeCommune) {
   const communeCOG = getCommuneCOG(codeCommune)
   const commune = await getCommune(codeCommune)
@@ -43,7 +57,9 @@ async function composeCommune(codeCommune) {
     throw new Error(`La commune ${codeCommune} n’existe pas.`)
   }
 
-  const balData = await getSourceData('bal', codeCommune)
+  const currentRevision = await getCurrentRevision(codeCommune)
+
+  const balData = await getBalData(codeCommune, currentRevision)
   const isBAL = balData.adresses.length > 0
 
   // Contrôle à supprimer dès lors que le Moissonneur v2 sera en place

--- a/lib/compose/index.js
+++ b/lib/compose/index.js
@@ -26,7 +26,6 @@ async function getMultiSourcesData(codeCommune) {
     'ign-api-gestion',
     'cadastre',
     'ftth',
-    'bal',
     'insee-ril'
   ]
 

--- a/lib/compose/sources/bal.js
+++ b/lib/compose/sources/bal.js
@@ -6,7 +6,7 @@ const updateCommunes = require('../processors/update-communes')
 const filterOutOfCommune = require('../processors/filter-out-of-commune')
 
 function buildLieuDit(adresse) {
-  const {position, codeCommune, idVoie, nomVoie, nomVoieAlt, nomCommune, codeAncienneCommune, nomAncienneCommune, parcelles} = adresse
+  const {position, codeCommune, idVoie, nomVoie, nomVoieAlt, nomCommune, codeAncienneCommune, nomAncienneCommune, parcelles, dateMAJ} = adresse
   const {lon, lat, x, y, tiles} = derivePositionProps(position, 10, 14)
   const {codePostal} = getCodePostalRecord(codeCommune)
 
@@ -22,6 +22,7 @@ function buildLieuDit(adresse) {
     nomAncienneCommune,
     codePostal,
     parcelles,
+    dateMAJ,
     lon,
     lat,
     x,

--- a/lib/compose/strategies/bal/numero.js
+++ b/lib/compose/strategies/bal/numero.js
@@ -40,7 +40,7 @@ function getBestPosition(positions) {
 }
 
 function buildNumero(numeroAdresses, {idVoieFantoir, codeCommune, forceCertification}) {
-  const {numero, lieuDitComplementNom, lieuDitComplementNomAlt, parcelles, certificationCommune, codeAncienneCommune, nomAncienneCommune} = numeroAdresses[0]
+  const {numero, lieuDitComplementNom, lieuDitComplementNomAlt, parcelles, certificationCommune, codeAncienneCommune, nomAncienneCommune, dateMAJ} = numeroAdresses[0]
   const suffixe = normalizeSuffixe(numeroAdresses[0].suffixe)
 
   const positions = numeroAdresses
@@ -64,6 +64,7 @@ function buildNumero(numeroAdresses, {idVoieFantoir, codeCommune, forceCertifica
     lieuDitComplementNomAlt: lieuDitComplementNomAlt ? mapValues(nom => beautifyUppercased(nom)) : {},
     parcelles: parcelles || [],
     sources: ['bal'],
+    dateMAJ,
     certifie: forceCertification || certificationCommune,
     position,
     positionType,

--- a/lib/formatters/csv-bal.js
+++ b/lib/formatters/csv-bal.js
@@ -50,7 +50,7 @@ function buildRow(voie, numero, position, includesAlt = false) {
     lat: '',
     cad_parcelles: numero.parcelles ? numero.parcelles.join('|') : '',
     source: getSource(numero.sourcePosition) || getSource(voie.sourceNomVoie) || '',
-    date_der_maj: '',
+    date_der_maj: numero.dateMAJ || '',
     certification_commune: numero.certifie ? '1' : '0'
   }
   if (includesAlt) {
@@ -86,7 +86,8 @@ function createFakeNumero(voie) {
     cleInterop: voie.idVoie + '_99999',
     numero: 99_999,
     codeAncienneCommune: voie.codeAncienneCommune,
-    nomAncienneCommune: voie.nomAncienneCommune
+    nomAncienneCommune: voie.nomAncienneCommune,
+    dateMAJ: voie.dateMAJ
   }
 }
 

--- a/lib/formatters/geojson.js
+++ b/lib/formatters/geojson.js
@@ -19,7 +19,8 @@ function prepareAdresse(numero, voie) {
     nomAncienneCommune: voie.nomAncienneCommune,
     sourcePosition: numero.sourcePosition,
     sourceNomVoie: voie.sourceNomVoie,
-    certifie: numero.certifie
+    certifie: numero.certifie,
+    dateMAJ: numero.dateMAJ
   }))
 }
 
@@ -34,7 +35,8 @@ function prepareToponyme(voie) {
     codeAncienneCommune: voie.codeAncienneCommune,
     nomAncienneCommune: voie.nomAncienneCommune,
     sourceNomVoie: voie.sourceNomVoie,
-    nbNumeros: voie.nbNumeros
+    nbNumeros: voie.nbNumeros,
+    dateMAJ: voie.dateMAJ
   }))
 }
 

--- a/lib/models/commune.js
+++ b/lib/models/commune.js
@@ -175,7 +175,7 @@ async function getPopulatedCommune(codeCommune) {
 }
 
 async function getPopulatedVoie(idVoie) {
-  const voieFields = ['type', 'idVoie', 'nomVoie', 'nomVoieAlt', 'sourceNomVoie', 'sources', 'codeCommune', 'nbNumeros', 'nbNumerosCertifies', 'displayBBox']
+  const voieFields = ['type', 'idVoie', 'nomVoie', 'nomVoieAlt', 'sourceNomVoie', 'sources', 'codeCommune', 'nbNumeros', 'nbNumerosCertifies', 'displayBBox', 'dateMAJ']
 
   const voie = await mongo.db.collection('voies')
     .findOne({idVoie}, {projection: fieldsToProj(voieFields)})
@@ -187,7 +187,7 @@ async function getPopulatedVoie(idVoie) {
   const commune = getCommuneCOG(voie.codeCommune)
   const communeFields = ['nom', 'code', 'departement', 'region']
 
-  const numerosFields = ['numero', 'suffixe', 'lieuDitComplementNom', 'lieuDitComplementNomAlt', 'parcelles', 'sources', 'position', 'positionType', 'sourcePosition', 'certifie', 'codePostal', 'libelleAcheminement', 'id']
+  const numerosFields = ['numero', 'suffixe', 'lieuDitComplementNom', 'lieuDitComplementNomAlt', 'parcelles', 'sources', 'position', 'positionType', 'sourcePosition', 'certifie', 'codePostal', 'libelleAcheminement', 'id', 'dateMAJ']
 
   const numeros = await mongo.db.collection('numeros')
     .find({idVoie})

--- a/lib/models/commune.js
+++ b/lib/models/commune.js
@@ -121,7 +121,9 @@ async function getCommunesSummary() {
     'population',
     'typeComposition',
     'analyseAdressage',
-    'composedAt'
+    'composedAt',
+    'idRevision',
+    'dateRevision'
   ]
   const communesSummaries = await mongo.db.collection('communes')
     .find({})
@@ -150,7 +152,9 @@ async function getPopulatedCommune(codeCommune) {
     'nbVoies',
     'nbLieuxDits',
     'typeComposition',
-    'displayBBox'
+    'displayBBox',
+    'idRevision',
+    'dateRevision'
   ]
 
   const commune = await mongo.db.collection('communes')

--- a/lib/models/commune.js
+++ b/lib/models/commune.js
@@ -43,7 +43,7 @@ function getAskedComposition() {
 }
 
 async function updateCommune(codeCommune, changes) {
-  await mongo.db.collection('communes').findOneAndUpdate({codeCommune}, {$set: changes})
+  await mongo.db.collection('communes').findOneAndUpdate({codeCommune}, {$set: changes}, {upsert: true})
 }
 
 async function updateCommunesForceCertification(forceCertificationList) {

--- a/lib/util/api-depot.js
+++ b/lib/util/api-depot.js
@@ -1,0 +1,22 @@
+const process = require('process')
+const got = require('got')
+
+const API_DEPOT_URL = process.env.API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot'
+
+async function getCurrentRevision(codeCommune) {
+  try {
+    return await got(`${API_DEPOT_URL}/communes/${codeCommune}/current-revision`).json()
+  } catch (error) {
+    if (error.response?.statusCode === 404) {
+      return
+    }
+
+    throw error
+  }
+}
+
+async function getRevisionFile(revisionId) {
+  return got(`${API_DEPOT_URL}/revisions/${revisionId}/files/bal/download`).buffer()
+}
+
+module.exports = {getCurrentRevision, getRevisionFile}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "start": "node server"
   },
   "dependencies": {
+    "@ban-team/validateur-bal": "^2.11.0",
     "@etalab/adresses-util": "^0.8.2",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/fantoir": "^0.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,29 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@ban-team/shared-data@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.1.0.tgz#5c1ee73fd98b86723ee9893a426cbfd9a6e5f6b6"
+  integrity sha512-+SnPGySf715hd2pvygtCN24uGZNBMAeY8mNvt1WC7a+sPtjz74HL7+S+ff7SiZIrSYioSJi+OZp5t8QHgk2X/A==
+
+"@ban-team/validateur-bal@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.11.0.tgz#3707aab531f720614d9c842db41ff510d92918d8"
+  integrity sha512-jyixz2ZhvFic4TQKzRyUcZoWDCXoiGfxrxp637kVeG4Yt+BIJW65Ze02qWa9F4OCZJxGNwj8asNzP6HJlEnXcA==
+  dependencies:
+    "@ban-team/shared-data" "^1.1.0"
+    "@etalab/project-legal" "^0.6.0"
+    blob-to-buffer "^1.2.9"
+    bluebird "^3.7.2"
+    chalk "^4.1.2"
+    chardet "^1.4.0"
+    date-fns "^2.29.3"
+    file-type "^12.4.2"
+    iconv-lite "^0.6.3"
+    lodash "^4.17.21"
+    papaparse "^5.3.2"
+    yargs "^17.5.1"
+
 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz#29f92c30bb3e771e4a2048c95fa6855392dfac4f"
@@ -1928,6 +1951,11 @@ bl@^4.0.3, bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+blob-to-buffer@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/blob-to-buffer/-/blob-to-buffer-1.2.9.tgz#a17fd6c1c564011408f8971e451544245daaa84a"
+  integrity sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA==
+
 bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -2125,7 +2153,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2145,6 +2173,11 @@ chalk@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.1.tgz#ca57d71e82bb534a296df63bbacc4a1c22b2a4b6"
   integrity sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==
+
+chardet@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-1.5.0.tgz#c35b3e9a5994f7574688d1607a2ea9c723ebca95"
+  integrity sha512-Nj3VehbbFs/1ZnJJJaL3ztEf3Nu5Fs6YV/NBs6lyz/iDDHUU+X9QNk5QgPy1/5Rjtb/cGVf+NyazP7kVEJqKRg==
 
 chokidar@^3.5.3:
   version "3.5.3"
@@ -2484,6 +2517,11 @@ date-fns@^2.28.0:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
   integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 date-time@^3.1.0:
   version "3.1.0"
@@ -3382,6 +3420,11 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-type@^12.4.2:
+  version "12.4.2"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-12.4.2.tgz#a344ea5664a1d01447ee7fb1b635f72feb6169d9"
+  integrity sha512-UssQP5ZgIOKelfsaB5CuGAL+Y+q7EmONuiwF3N5HAH0t27rvrttgi6Ra9k/+DVaY9UF6+ybxu5pOXLUdA8N7Vg==
 
 file-uri-to-path@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Lorsqu'une BAL est présente sur l'API de dépôt, la composition du référentiel BAN pour cette commune utilise direction l'API de dépôt, et ne passe plus par l'étape d'import du fichier intermédiaire `adresses-locales` ana `import/bal`.

Tous les champs du format BAL sont mappés sur le modèle d'entrée (`sources_adresses`) sans transiter par la collection MongoDB.

TODO:
- [x] Propagation de la date de MAJ
- [x] Prise en compte des métadonnées de révision dans le modèle `Commune`
- [x] Diffusion des nouvelles métadonnées dans le fichier "État de la Base Adresse Nationale"