### PR TITLE
Route permettant de déclencher la consolidation des adresses d'une commune

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,3 +17,5 @@ DATAGOUV_API_KEY=
 BAL_URL_PATTERN=https://adresse.data.gouv.fr/data/adresses-locales/latest/csv/adresses-locales-{dep}.csv.gz
 
 API_DEPOT_URL=https://plateforme.adresse.data.gouv.fr/api-depot
+
+ADMIN_TOKEN=

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -8,6 +8,20 @@ const {prepareAdresses: prepareAdressesBal, extractHeaders} = require('../format
 const w = require('../util/w')
 const serveMvt = require('../util/serve-mvt')
 
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN
+
+function ensureIsAdmin(req, res, next) {
+  if (!ADMIN_TOKEN) {
+    return res.status(401).send({code: 401, message: 'Aucun jeton d’administration n’a été défini'})
+  }
+
+  if (req.get('Authorization') !== `Token ${ADMIN_TOKEN}`) {
+    return res.status(401).send({code: 401, message: 'Vous n’êtes pas autorisé à effectuer cette action'})
+  }
+
+  next()
+}
+
 const app = new express.Router()
 
 app.param('codeCommune', w(async (req, res, next) => {

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -7,8 +7,9 @@ const {prepareAdresses: prepareAdressesLegacy, prepareLieuxDits} = require('../f
 const {prepareAdresses: prepareAdressesBal, extractHeaders} = require('../formatters/csv-bal')
 const w = require('../util/w')
 const serveMvt = require('../util/serve-mvt')
+const composeCommune = require('../jobs/compose-commune')
 
-const ADMIN_TOKEN = process.env.ADMIN_TOKEN
+const {ADMIN_TOKEN} = process.env
 
 function ensureIsAdmin(req, res, next) {
   if (!ADMIN_TOKEN) {
@@ -58,6 +59,21 @@ app.get('/ban/communes/:codeCommune/download/csv-legacy/lieux-dits', w(async (re
     .attachment(`lieux-dits-${codeCommune}.csv`)
     .type('text/csv')
     .send(csvFile)
+}))
+
+app.post('/ban/communes/:codeCommune/compose', ensureIsAdmin, w(async (req, res) => {
+  const {codeCommune} = req.params
+  const now = new Date()
+
+  const communeEntry = await getCommune(codeCommune)
+  if (!communeEntry) {
+    return res.status(404).send({code: 404, message: 'La commune n’existe pas'})
+  }
+
+  await composeCommune({codeCommune, compositionAskedAt: now})
+  const commune = await getCommune(codeCommune)
+
+  return res.send(commune)
 }))
 
 app.get('/ban/communes/:codeCommune/download/csv-bal/adresses', w(async (req, res) => {

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -65,11 +65,6 @@ app.post('/ban/communes/:codeCommune/compose', ensureIsAdmin, w(async (req, res)
   const {codeCommune} = req.params
   const now = new Date()
 
-  const communeEntry = await getCommune(codeCommune)
-  if (!communeEntry) {
-    return res.status(404).send({code: 404, message: 'La commune n’existe pas'})
-  }
-
   await composeCommune({codeCommune, compositionAskedAt: now})
   const commune = await getCommune(codeCommune)
 

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -65,7 +65,7 @@ app.get('/ban/communes/:codeCommune/download/csv-legacy/lieux-dits', w(async (re
 
 app.post('/ban/communes/:codeCommune/compose', ensureIsAdmin, w(async (req, res) => {
   const {codeCommune} = req.commune
-  const {force} = req.body?.options || {force: false}
+  const {force} = req.body
 
   await Commune.askComposition(req.commune.codeCommune, {force})
   const commune = await getCommune(codeCommune)

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -25,6 +25,8 @@ function ensureIsAdmin(req, res, next) {
 
 const app = new express.Router()
 
+app.use(express.json())
+
 app.param('codeCommune', w(async (req, res, next) => {
   const {codeCommune} = req.params
   const commune = await getCommune(codeCommune)

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -7,7 +7,7 @@ const {prepareAdresses: prepareAdressesLegacy, prepareLieuxDits} = require('../f
 const {prepareAdresses: prepareAdressesBal, extractHeaders} = require('../formatters/csv-bal')
 const w = require('../util/w')
 const serveMvt = require('../util/serve-mvt')
-const composeCommune = require('../jobs/compose-commune')
+const Commune = require('../models/commune')
 
 const {ADMIN_TOKEN} = process.env
 
@@ -62,10 +62,9 @@ app.get('/ban/communes/:codeCommune/download/csv-legacy/lieux-dits', w(async (re
 }))
 
 app.post('/ban/communes/:codeCommune/compose', ensureIsAdmin, w(async (req, res) => {
-  const {codeCommune} = req.params
-  const now = new Date()
+  const {codeCommune} = req.commune
 
-  await composeCommune({codeCommune, compositionAskedAt: now})
+  await Commune.askComposition(req.commune.codeCommune)
   const commune = await getCommune(codeCommune)
 
   return res.send(commune)

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -63,8 +63,9 @@ app.get('/ban/communes/:codeCommune/download/csv-legacy/lieux-dits', w(async (re
 
 app.post('/ban/communes/:codeCommune/compose', ensureIsAdmin, w(async (req, res) => {
   const {codeCommune} = req.commune
+  const {force} = req.body?.options || {force: false}
 
-  await Commune.askComposition(req.commune.codeCommune)
+  await Commune.askComposition(req.commune.codeCommune, {force})
   const commune = await getCommune(codeCommune)
 
   return res.send(commune)


### PR DESCRIPTION
## Contexte
Cette PR a pour objectif de mettre à disposition une route protégée permettant de demander manuellement l'opération `compose` pour une commune donnée.

## Évolutions
- Nouvelle variable d'environnement `ADMIN_TOKEN`
- Ajout d'un middleware `ensureIsAdmin` protégeant les appels administrateur
- Nouvelle route `POST /ban/communes/:codeCommune/compose` déclenchant l'opération `compose` pour la commune précisée en paramètre. Cette route renverra la commune mise à jour.