### PR TITLE
Ne déclencher la "composition" que si les adresses ont changé sur l'API de dépôt

### DIFF
--- a/lib/compose/index.js
+++ b/lib/compose/index.js
@@ -52,6 +52,7 @@ async function getBalData(codeCommune, revision) {
 async function composeCommune(codeCommune) {
   const communeCOG = getCommuneCOG(codeCommune)
   const commune = await getCommune(codeCommune)
+  const compositionOptions = commune.compositionOptions || {}
 
   if (!communeCOG) {
     throw new Error(`La commune ${codeCommune} n’existe pas.`)
@@ -59,12 +60,17 @@ async function composeCommune(codeCommune) {
 
   const currentRevision = await getCurrentRevision(codeCommune)
 
+  if (!compositionOptions.force && currentRevision && commune.idRevision === currentRevision?._id) {
+    console.log(`${codeCommune} | révision source inchangée => composition ignorée`)
+    return
+  }
+
   const balData = await getBalData(codeCommune, currentRevision)
   const isBAL = balData.adresses.length > 0
 
   // Contrôle à supprimer dès lors que le Moissonneur v2 sera en place
   if (!isBAL && commune?.typeComposition === 'bal') {
-    console.log(`Composition des adresses de la commune ${codeCommune} abandonnée => régression vers assemblage interdite`)
+    console.log(`${codeCommune} | passage de 'bal' à 'assemblage' interdit => composition ignorée`)
     return
   }
 

--- a/lib/models/commune.js
+++ b/lib/models/commune.js
@@ -4,7 +4,7 @@ const {getCommuneActuelle, getRegion, getDepartement, getCommune: getCommuneCOG}
 const compositionQueue = require('../util/queue')('compose-commune')
 const {prepareAdresse, prepareToponyme} = require('../formatters/geojson')
 
-async function askComposition(codeCommune) {
+async function askComposition(codeCommune, options = {}) {
   const communeActuelle = getCommuneActuelle(codeCommune)
 
   if (!communeActuelle) {
@@ -14,7 +14,7 @@ async function askComposition(codeCommune) {
   const now = new Date()
   await mongo.db.collection('communes').findOneAndUpdate(
     {codeCommune: communeActuelle.code},
-    {$set: {compositionAskedAt: now}},
+    {$set: {compositionAskedAt: now, compositionOptions: options}},
     {upsert: true}
   )
   await compositionQueue.add({codeCommune: communeActuelle.code, compositionAskedAt: now}, {removeOnComplete: true})
@@ -23,14 +23,14 @@ async function askComposition(codeCommune) {
 async function askCompositionAll() {
   await mongo.db.collection('communes').updateMany(
     {},
-    {$set: {compositionAskedAt: new Date()}}
+    {$set: {compositionAskedAt: new Date(), compositionOptions: {force: true}}}
   )
 }
 
 async function finishComposition(codeCommune) {
   await mongo.db.collection('communes').findOneAndUpdate(
     {codeCommune},
-    {$unset: {compositionAskedAt: 1}, $set: {composedAt: new Date()}}
+    {$unset: {compositionAskedAt: 1, compositionOptions: 1}, $set: {composedAt: new Date()}}
   )
 }
 
@@ -62,7 +62,7 @@ async function updateCommunesForceCertification(forceCertificationList) {
     {$set: {forceCertification: true}}
   )
 
-  await Promise.all([...toRemoveList, ...toAddList].map(codeCommune => askComposition(codeCommune)))
+  await Promise.all([...toRemoveList, ...toAddList].map(codeCommune => askComposition(codeCommune, {force: true})))
 
   return {communesAdded: toAddList, communesRemoved: toRemoveList}
 }

--- a/scripts/update-cog.js
+++ b/scripts/update-cog.js
@@ -15,7 +15,7 @@ async function main() {
 
   for (const missingCommune of missingCommunes) {
     console.log(`Création de la commune ${missingCommune.code}`)
-    await askComposition(missingCommune.code)
+    await askComposition(missingCommune.code, {force: true})
   }
 
   const obsoleteCodes = codesCommunesBAN.filter(c => !getCommune(c))


### PR DESCRIPTION
Le fonctionnement initial effectuait une étape `compose` à chaque appel, y compris si la révision source était inchangée.
Avec cette adaptation l'étape `compose` est annulée si la révision courante est identique à celle enregistrée dans la base de données.
Il est possible de déroger à ce comportement en passant `{force: true}`, ce qui va être pertinent notamment quand on modifie un algorithme de transformation des adresses.