### PR TITLE
fix partiel erreur compose

### DIFF
--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -1,3 +1,4 @@
+const fs = require('node:fs')
 const express = require('express')
 const Papa = require('papaparse')
 const {snakeCase, mapKeys} = require('lodash')
@@ -67,10 +68,24 @@ app.post('/ban/communes/:codeCommune/compose', ensureIsAdmin, w(async (req, res)
   const {codeCommune} = req.commune
   const {force} = req.body
 
-  await Commune.askComposition(req.commune.codeCommune, {force})
-  const commune = await getCommune(codeCommune)
-
-  return res.send(commune)
+  try {
+    await Commune.askComposition(codeCommune, {force})
+    const commune = await getCommune(codeCommune)
+    return res.send(commune)
+  } catch (error) {
+    const errMsg = `--- 
+${(new Date()).toUTCString()}
+codeCommune : ${codeCommune} 
+erreur : ${error}
+---
+`
+    fs.appendFile('errorCompose.log', errMsg, error => {
+      if (error) {
+        throw error
+      }
+    })
+    return res.sendStatus(500)
+  }
 }))
 
 app.get('/ban/communes/:codeCommune/download/csv-bal/adresses', w(async (req, res) => {


### PR DESCRIPTION
try catch sur route compose pour la promesse dans route.js
Ecriture dans un fichier errorCompose.log à la racine de ban-plateforme.
exemple : 
--- 
Fri, 18 Nov 2022 13:17:24 GMT
codeCommune : 59656 
erreur : Error: et bim
---

Permet de savoir quelles communes ont planté et de les relancer à la main.
En attendant une solution pérenne.