### PR TITLE
Réduction du périmètre de prise en compte des adresses FTTH

### DIFF
--- a/lib/compose/processors/filter-out-of-commune.js
+++ b/lib/compose/processors/filter-out-of-commune.js
@@ -10,7 +10,7 @@ function immediate() {
   })
 }
 
-async function filterOutOfCommune(context) {
+async function filterOutOfCommune(context, maxDistance = 5) {
   const {codeCommune, adresses} = context
 
   const contour = await getContour(codeCommune)
@@ -29,7 +29,7 @@ async function filterOutOfCommune(context) {
 
     const distance = distanceToPolygon(feature(adresse.position), contour)
 
-    if (distance > 5) {
+    if (distance > maxDistance) {
       console.log(`Position trop éloignée de la commune ${codeCommune} : ${distance.toFixed(2)} km`)
       return
     }

--- a/lib/compose/sources/ftth.js
+++ b/lib/compose/sources/ftth.js
@@ -6,7 +6,7 @@ const filterOutOfCommune = require('../processors/filter-out-of-commune')
 async function prepareData(adressesCommune, {codeCommune}) {
   const context = {adresses: adressesCommune, codeCommune}
 
-  await filterOutOfCommune(context)
+  await filterOutOfCommune(context, 0.2)
 
   const filteredAdresses = context.adresses.filter(a => {
     // Suppression des pseudo-numéros, approche grossière pour commencer.


### PR DESCRIPTION
Compte-tenu de la non-qualité du fichier du déploiement FTTH de l'Arcep, il arrive fréquemment que des adresses ne soient pas attribuées à la bonne commune.

S'il est légitime d'accepter des adresses qui débordent légèrement du contour de la commune en raison des contraintes de voirie et d'adressage, il est clair que sur cette source de données la limite à 5km est excessive et génère beaucoup d'erreurs.

Cette pull request introduit un paramètre `maxDistance` pour le traitement de filtrage des adresses hors de la commune.
Il est défini par défaut à `5` par cohérence avec le comportement actuel.

La paramètre est ensuite fixé à `0.2` soit 200 mètres pour la source FTTH.