### PR TITLE
Deleted useless env variables in sample file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,7 +14,6 @@ COMMUNES=
 MAX_CONCURRENT_WORKERS=1
 
 DATAGOUV_API_KEY=
-BAL_URL_PATTERN=https://adresse.data.gouv.fr/data/adresses-locales/latest/csv/adresses-locales-{dep}.csv.gz
 
 API_DEPOT_URL=https://plateforme.adresse.data.gouv.fr/api-depot
 


### PR DESCRIPTION
This pull request aims to clean the .env.sample file so that we always have a file up-to-date with the used variables
 
The following env variables are used nowhere in the ban-plateforme code : 
- MAJIC_PATH
- BAL_URL_PATTERN
