### PR TITLE
Implementation docker for production deploy

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,27 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+
+jobs:
+
+  docker:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Login to image repository
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        push: true
+        tags: ban/ban-plateforme:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# using an optimized node image
+FROM node:16.19.0-alpine
+
+RUN npm install pm2 -g
+
+# optimzing caching for yarn install
+WORKDIR /app
+COPY package.json yarn.lock .
+RUN yarn install
+
+# creating /data and /dist folder to be able to map volumes
+RUN mkdir data && mkdir dist
+
+# copying the root folder into the workdir taking into account the .dockerignore file
+COPY . .
+
+CMD ["pm2-runtime", "process.yml"]

--- a/process.yml
+++ b/process.yml
@@ -1,0 +1,12 @@
+apps:
+  - name : 'ban-api'
+    script : 'server.js'
+    instances: '2'
+    env:
+      PORT : 5000
+      NODE_ENV : 'production'
+  - name : 'ban-worker'
+    script : 'worker.js'
+    instances: '4'
+    env:
+      NODE_ENV : 'production'


### PR DESCRIPTION
This pull request aims to prepare implementation of the ban-plateforme docker image for production by : 
- Defining the production image (Dockerfile)
- Defining the github workflow to build and push the image in the Docker Hub, the job being triggered at each push in the 'master' branch (and so, during each merge into master)

What still need to to done (that's why the pull request is still in DRAFT mode) :

- Create a BAN registry in DockerHub (example: ban/ban-plateforme). We can create a free Docker Hub account for the BAN open source community (limit = 200 container image requests per six hours).
- Add github secret to login to the docker hub registry : DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
That done, the only command that will need to be started on the ban-server will be :

docker run 
-p 5000:5000 
-v /data:/app/data 
-v /dist:/app/dist
--env-file ./app-env 
ban/ban-plateforme

Comments on the above command
-p 5000:5000 = mapping inner docker container port 5000 to external port 5000
-v = map server host /data and /dist folder to the container /data and /dist folder
--env-file ./app-env = Inject env variable from the file 'app-env' (file can have another name)