### PR TITLE
modification route lookup pour les lieux-dit ajout des numéros liés

### DIFF
--- a/lib/models/commune.js
+++ b/lib/models/commune.js
@@ -191,13 +191,24 @@ async function getPopulatedVoie(idVoie) {
   const commune = getCommuneCOG(voie.codeCommune)
   const communeFields = ['nom', 'code', 'departement', 'region']
 
-  const numerosFields = ['numero', 'suffixe', 'lieuDitComplementNom', 'lieuDitComplementNomAlt', 'parcelles', 'sources', 'position', 'positionType', 'sourcePosition', 'certifie', 'codePostal', 'libelleAcheminement', 'id', 'dateMAJ']
+  const numeroLDFields = ['numero', 'suffixe', 'idVoie', 'parcelles', 'sources', 'position', 'positionType', 'sourcePosition', 'certifie', 'codePostal', 'libelleAcheminement', 'id', 'dateMAJ']
+  const numerosVoieFields = ['numero', 'suffixe', 'lieuDitComplementNom', 'lieuDitComplementNomAlt', 'parcelles', 'sources', 'position', 'positionType', 'sourcePosition', 'certifie', 'codePostal', 'libelleAcheminement', 'id', 'dateMAJ']
 
-  const numeros = await mongo.db.collection('numeros')
-    .find({idVoie})
-    .project(fieldsToProj(numerosFields))
-    .sort({cleInterop: 1})
-    .toArray()
+  let numeros
+  if (voie.type === 'voie') {
+    numeros = await mongo.db.collection('numeros')
+      .find({idVoie})
+      .project(fieldsToProj(numerosVoieFields))
+      .sort({cleInterop: 1})
+      .toArray()
+  } else {
+    // Lieu-dit
+    numeros = await mongo.db.collection('numeros')
+      .find({lieuDitComplementNom: voie.nomVoie, codeCommune: voie.codeCommune})
+      .project(fieldsToProj(numeroLDFields))
+      .sort({cleInterop: 1})
+      .toArray()
+  }
 
   return {
     id: voie.idVoie,


### PR DESCRIPTION
Test lorsqu'on trouve un document dans le lookup des voies si c'est un lieu dit on ajoute les numéros liés (ie ceux qui ont llieux dit complement Nom rempli avec le libellé du lieux dit sur la commune).

Cela donne pour la Haute Folie à Breux sur Avre : (extrait)
**On récupère dans le numéro l'idVoie qui permettra ensuite de classer les numéros en les groupant par voie.
Il faudra donc faire une requête supplémentaire par idVoie pour récupérer le libellé à afficher dans la liste de l'explorateur adresse.data.gouv.fr.**
{
  "id": "27115_B023",
  "type": "lieu-dit",
  "idVoie": "27115_B023",
  "nomVoie": "La Haute Folie",
  "nomVoieAlt": {},
  "dateMAJ": "2020-07-03",
  "displayBBox": [
    1.0797,
    48.7713,
    1.0824,
    48.7731
  ],
  "commune": {
    "id": "27115",
    "nom": "Breux-sur-Avre",
    "code": "27115",
    "departement": {
      "nom": "Eure",
      "code": "27"
    },
    "region": {
      "nom": "Normandie",
      "code": "28"
    }
  },
  "numeros": [
    {
      "**idVoie": "27115_0043",**
      "numero": 2,
      "suffixe": null,
      "lieuDitComplementNomAlt": {},
      "parcelles": [],
      "sources": [
        "bal"
      ],
      "dateMAJ": "2021-09-06",
      "certifie": true,
      "position": {
        "type": "Point",
        "coordinates": [
          1.085651,
          48.773186
        ]
      },
      "positionType": "entrée",
      "sourcePosition": "bal",
      "codePostal": "27570",
      "libelleAcheminement": "BREUX SUR AVRE",
      "id": "27115_0043_00002"
    },
    
....