### PR TITLE
Feature/ban platform api put and delete

### DIFF
--- a/lib/api/address/consumers.js
+++ b/lib/api/address/consumers.js
@@ -1,10 +1,11 @@
-import {setAddresses, updateAddresses, setAddressJobStatus} from './models.js'
-import {checkAddresses} from './utils.js'
+import {setAddresses, updateAddresses, deleteAddresses, setAddressJobStatus} from './models.js'
+import {checkAddressesRequest} from './utils.js'
 
 export default async function addressConsumer({data: {type, addresses, statusID}}, done) {
   const addressesCount = addresses.length
   try {
-    const addressesValidation = await checkAddresses(addresses, type)
+    const addressesValidation = await checkAddressesRequest(addresses, type)
+
     if (addressesValidation.isValid) {
       switch (type) {
         case 'insert':
@@ -12,6 +13,9 @@ export default async function addressConsumer({data: {type, addresses, statusID}
           break
         case 'update':
           await updateAddresses(addresses)
+          break
+        case 'delete':
+          await deleteAddresses(addresses.map(({id}) => id))
           break
         default:
           console.warn(`Address Consumer Warn: Unknown job type : '${type}'`)

--- a/lib/api/address/models.js
+++ b/lib/api/address/models.js
@@ -29,6 +29,11 @@ export async function updateAddresses(addresses) {
   return mongo.db.collection(COLLECTION_ADDRESS).bulkWrite(bulkOperations)
 }
 
+export async function deleteAddresses(addressIDs) {
+  // TODO: Use status or historic collection for conserve event trace.
+  return mongo.db.collection(COLLECTION_ADDRESS).deleteMany({id: {$in: addressIDs}})
+}
+
 export async function getAdressJobStatus(statusID) {
   return mongo.db.collection(COLLECTION_JOB_STATUS).findOne({id: statusID})
 }

--- a/lib/api/address/routes.js
+++ b/lib/api/address/routes.js
@@ -102,6 +102,34 @@ app.put('/', auth, async (req, res) => {
   res.send(response)
 })
 
+app.delete('/', auth, async (req, res) => {
+  let response
+  try {
+    const addresses = req.body
+    const statusID = nanoid()
+
+    await addressQueue.add(
+      {type: 'delete', addresses, statusID},
+      {jobId: statusID, removeOnComplete: true}
+    )
+    response = {
+      date: new Date(),
+      status: 'success',
+      message: `Check the status of your request : ${BAN_API_URL}/address/status/${statusID}`,
+      response: {statusID},
+    }
+  } catch (error) {
+    response = {
+      date: new Date(),
+      status: 'error',
+      message: error,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
 app.get('/status/:statusID', async (req, res) => {
   let response
   try {

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -26,7 +26,7 @@ const banAddressValidation = async address => {
   return report(true)
 }
 
-export const checkAddresses = async (addresses, type) => {
+export const checkAddressesRequest = async (addresses, type) => {
   const adresseIDs = addresses.map(address => address.id)
 
   if (adresseIDs.length === 0) {
@@ -69,7 +69,7 @@ export const checkAddresses = async (addresses, type) => {
     }
   }
 
-  if (type === 'update') {
+  if (type === 'update' || type === 'delete') {
     // Check if IDs are already existing in BDD
     const existingIDs = await getExistingIDs(adresseIDs)
     if (existingIDs.length !== adresseIDs.length) {

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -3,7 +3,7 @@ import {object, string, bool, array} from 'yup'
 import {addressMock, bddMock} from './__mocks__/data-mock.js'
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/models.js'))
-const {checkAddresses} = await import('./utils.js')
+const {checkAddressesRequest} = await import('./utils.js')
 
 const addressesValidationSchema = object({
   isValid: bool().required(),
@@ -13,10 +13,10 @@ const addressesValidationSchema = object({
   }),
 })
 
-describe('checkAddresses', () => {
+describe('checkAddressesRequest', () => {
   it('Shared  IDs', async () => {
     const sharedID = '00000000-0000-4fff-9fff-aaaaaaaaaaaa'
-    const addressesValidation = await checkAddresses(addressMock.map(addr => ({...addr, id: sharedID})), 'insert')
+    const addressesValidation = await checkAddressesRequest(addressMock.map(addr => ({...addr, id: sharedID})), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -24,7 +24,7 @@ describe('checkAddresses', () => {
   })
 
   it('All unavailable IDs', async () => {
-    const addressesValidation = await checkAddresses(bddMock.map(({_id, ...addr}) => addr), 'insert')
+    const addressesValidation = await checkAddressesRequest(bddMock.map(({_id, ...addr}) => addr), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -33,7 +33,7 @@ describe('checkAddresses', () => {
   })
 
   it('Some unavailable IDs', async () => {
-    const addressesValidation = await checkAddresses([...addressMock, ...bddMock].map(({_id, ...addr}) => addr), 'insert')
+    const addressesValidation = await checkAddressesRequest([...addressMock, ...bddMock].map(({_id, ...addr}) => addr), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -42,14 +42,14 @@ describe('checkAddresses', () => {
   })
 
   it('Available addresses and IDs on Insert', async () => {
-    const addressesValidation = await checkAddresses(addressMock, 'insert')
+    const addressesValidation = await checkAddressesRequest(addressMock, 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)
   })
 
   it('Unknown IDs on Update', async () => {
-    const addressesValidation = await checkAddresses(addressMock, 'update')
+    const addressesValidation = await checkAddressesRequest(addressMock, 'update')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -57,7 +57,22 @@ describe('checkAddresses', () => {
   })
 
   it('Available addresses on Update', async () => {
-    const addressesValidation = await checkAddresses(bddMock.map(addr => ({...addr, voieLabel: 'Rue de la mouette'})), 'update')
+    const addressesValidation = await checkAddressesRequest(bddMock.map(addr => ({...addr, voieLabel: 'Rue de la mouette'})), 'update')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(true)
+  })
+
+  it('Unknow IDs on Delete', async () => {
+    const addressesValidation = await checkAddressesRequest(addressMock, 'delete')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    addressMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Available addresses on Update', async () => {
+    const addressesValidation = await checkAddressesRequest(bddMock, 'delete')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)


### PR DESCRIPTION
Cette PR va ajouter 2 nouvelles routes, pour la mise à jour et la suppression d'adresses, à l'API de BAN-Platform :

_**A noter** : Actuellement, les traitements de données se font sur une collection indépendante, nommée address_test_

Les tests peuvent être lancés via la commande :

```sh
yarn test
```

**A noter :**
_Ces routes nécessitent un token de connexion de 36 caractères, qui doit, au préalable, être renseignés sur la variable d'environnement `BAN_API_AUTHORIZED_TOKENS` et passé en 'en-tête' lors de l'appel à la route (`Authorization: token MON_TOKEN_DE_36_CARACTERES_xxxxxxxxx`)._ 
_Un token peut être généré localement en passant la commande `npx nanoid --alphabet 123456789ABCDEFGHJKMNPQRSTVWXYZ --size 36` dans un terminal (cette commande nécessite la présence de `npm`)_

### PUT > /address/
Mise à jour d'adresses. 

**Exemple de valeurs attendu en entrée :**
```json
[
  {
    "id": "00000000-0000-4fff-9fff-00000000000a", // Cette ID doit être présent dans la base
    "codeCommune": "12345",
    "voieLabel": "Rue de la baleine",
    "numero": 1,
  }
]
```   

**Retour :** Renvoie un Identifiant d'état, à utiliser avec la route d'extraction d'états.

### DELETE > /address/
Suppression d'adresses. 

**Exemple de valeurs attendu en entrée :**
```json
[
  {
    "id": "00000000-0000-4fff-9fff-00000000000a", // Cette ID doit être présent dans la base
  }
]
```   

**Retour :** Renvoie un Identifiant d'état, à utiliser avec la route d'extraction d'états.