### PR TITLE
BanID : Ajout d'une route d'api PUT pour la modification d'adresses

### DIFF
--- a/lib/api/address/__mocks__/data-mock.js
+++ b/lib/api/address/__mocks__/data-mock.js
@@ -3,20 +3,20 @@ export const addressMock = [
     id: '00000000-0000-4fff-9fff-00000000000a',
     codeCommune: '12345',
     voieLabel: 'Rue de la baleine',
-    numero: '1',
+    numero: 1,
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
     codeCommune: '12345',
     voieLabel: 'Rue de la baleine',
-    numero: '1',
+    numero: 1,
     suffixe: 'bis',
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000c',
     codeCommune: '12345',
     voieLabel: 'Rue de la baleine',
-    numero: '2',
+    numero: 2,
   }
 ]
 
@@ -28,7 +28,7 @@ export const bddMock = [
     id: '00000000-0000-4fff-9fff-000000000000',
     codeCommune: '12345',
     voieLabel: 'Rue du Renard',
-    numero: '10',
+    numero: 10,
     suffixe: 'ter',
   },
   {
@@ -38,7 +38,7 @@ export const bddMock = [
     id: '00000000-0000-4fff-9fff-000000000001',
     codeCommune: '12345',
     voieLabel: 'Rue du Renard',
-    numero: '15',
+    numero: 15,
   },
   {
     _id: {
@@ -47,6 +47,6 @@ export const bddMock = [
     id: '00000000-0000-4fff-9fff-000000000002',
     codeCommune: '12345',
     voieLabel: 'Rue du Renard',
-    numero: '6',
+    numero: 6,
   }
 ]

--- a/lib/api/address/consumers.js
+++ b/lib/api/address/consumers.js
@@ -4,7 +4,7 @@ import {checkAddresses} from './utils.js'
 export default async function addressConsumer({data: {type, addresses, statusID}}, done) {
   const addressesCount = addresses.length
   try {
-    const addressesValidation = await checkAddresses(type, addresses)
+    const addressesValidation = await checkAddresses(addresses, type)
     if (addressesValidation.isValid) {
       await setAddresses(addresses)
       await setAddressJobStatus(statusID, {

--- a/lib/api/address/consumers.js
+++ b/lib/api/address/consumers.js
@@ -1,4 +1,4 @@
-import {setAddresses, setAddressJobStatus} from './models.js'
+import {setAddresses, updateAddresses, setAddressJobStatus} from './models.js'
 import {checkAddresses} from './utils.js'
 
 export default async function addressConsumer({data: {type, addresses, statusID}}, done) {
@@ -6,7 +6,17 @@ export default async function addressConsumer({data: {type, addresses, statusID}
   try {
     const addressesValidation = await checkAddresses(addresses, type)
     if (addressesValidation.isValid) {
-      await setAddresses(addresses)
+      switch (type) {
+        case 'insert':
+          await setAddresses(addresses)
+          break
+        case 'update':
+          await updateAddresses(addresses)
+          break
+        default:
+          console.warn(`Address Consumer Warn: Unknown job type : '${type}'`)
+      }
+
       await setAddressJobStatus(statusID, {
         status: 'success',
         type,

--- a/lib/api/address/models.js
+++ b/lib/api/address/models.js
@@ -15,6 +15,20 @@ export async function setAddresses(addresses) {
   return mongo.db.collection(COLLECTION_ADDRESS).insertMany(addresses)
 }
 
+export async function updateAddresses(addresses) {
+  const bulkOperations = addresses.map(address => {
+    const filter = {id: address.id}
+    return {
+      updateOne: {
+        filter,
+        update: {$set: address}
+      }
+    }
+  })
+  // TODO: Use status or historic collection for conserve event trace.
+  return mongo.db.collection(COLLECTION_ADDRESS).bulkWrite(bulkOperations)
+}
+
 export async function getAdressJobStatus(statusID) {
   return mongo.db.collection(COLLECTION_JOB_STATUS).findOne({id: statusID})
 }

--- a/lib/api/address/routes.js
+++ b/lib/api/address/routes.js
@@ -74,6 +74,34 @@ app.post('/', auth, async (req, res) => {
   res.send(response)
 })
 
+app.put('/', auth, async (req, res) => {
+  let response
+  try {
+    const addresses = req.body
+    const statusID = nanoid()
+
+    await addressQueue.add(
+      {type: 'update', addresses, statusID},
+      {jobId: statusID, removeOnComplete: true}
+    )
+    response = {
+      date: new Date(),
+      status: 'success',
+      message: `Check the status of your request : ${BAN_API_URL}/address/status/${statusID}`,
+      response: {statusID},
+    }
+  } catch (error) {
+    response = {
+      date: new Date(),
+      status: 'error',
+      message: error,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
 app.get('/status/:statusID', async (req, res) => {
   let response
   try {

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -26,7 +26,7 @@ const banAddressValidation = async address => {
   return report(true)
 }
 
-export const checkAddresses = async (type, addresses) => {
+export const checkAddresses = async (addresses, type) => {
   if (type === 'insert') {
     const adresseIDs = addresses.map(address => address.id)
 

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -27,8 +27,28 @@ const banAddressValidation = async address => {
 }
 
 export const checkAddresses = async (addresses, type) => {
+  const adresseIDs = addresses.map(address => address.id)
+
+  if (adresseIDs.length === 0) {
+    return report(false, 'No address send to job')
+  }
+
   if (type === 'insert') {
-    const adresseIDs = addresses.map(address => address.id)
+    // Check if IDs are already existing in BDD
+    const existingIDs = await getExistingIDs(adresseIDs)
+    if (existingIDs.length > 0) {
+      return report(false, 'Unavailable IDs', existingIDs)
+    }
+  }
+
+  if (type === 'insert' || type === 'update') {
+  // Check address schema
+    const addressesValidationPromises = addresses.map(address => banAddressValidation(address))
+    const addressesValidation = await Promise.all(addressesValidationPromises)
+    const invalidAddresses = addressesValidation.filter(({isValid}) => !isValid)
+    if (invalidAddresses.length > 0) {
+      return report(false, 'Invalid format', invalidAddresses)
+    }
 
     // Check if IDs are uniq in the request
     const uniqAdresseIDs = [...new Set(adresseIDs)]
@@ -47,19 +67,13 @@ export const checkAddresses = async (addresses, type) => {
       ).reduce((acc, [key, values]) => (values.length > 1) ? [...acc, key] : acc, [])
       return report(false, 'Shared IDs in request', sharedIDs)
     }
+  }
 
+  if (type === 'update') {
     // Check if IDs are already existing in BDD
     const existingIDs = await getExistingIDs(adresseIDs)
-    if (existingIDs.length > 0) {
-      return report(false, 'Unavailable IDs', existingIDs)
-    }
-
-    // Check address schema
-    const addressesValidationPromises = addresses.map(address => banAddressValidation(address))
-    const addressesValidation = await Promise.all(addressesValidationPromises)
-    const invalidAddresses = addressesValidation.filter(({isValid}) => !isValid)
-    if (invalidAddresses.length > 0) {
-      return report(false, 'Invalid format', invalidAddresses)
+    if (existingIDs.length !== adresseIDs.length) {
+      return report(false, 'Some unknown IDs', adresseIDs.filter(id => !existingIDs.includes(id)))
     }
   }
 

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -41,15 +41,23 @@ describe('checkAddresses', () => {
     bddMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Available IDs on Insert', async () => {
+  it('Available addresses and IDs on Insert', async () => {
     const addressesValidation = await checkAddresses(addressMock, 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)
   })
 
-  it('Available IDs on Update', async () => {
+  it('Unknown IDs on Update', async () => {
     const addressesValidation = await checkAddresses(addressMock, 'update')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    addressMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Available addresses on Update', async () => {
+    const addressesValidation = await checkAddresses(bddMock.map(addr => ({...addr, voieLabel: 'Rue de la mouette'})), 'update')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -16,7 +16,7 @@ const addressesValidationSchema = object({
 describe('checkAddresses', () => {
   it('Shared  IDs', async () => {
     const sharedID = '00000000-0000-4fff-9fff-aaaaaaaaaaaa'
-    const addressesValidation = await checkAddresses('insert', addressMock.map(addr => ({...addr, id: sharedID})))
+    const addressesValidation = await checkAddresses(addressMock.map(addr => ({...addr, id: sharedID})), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -24,7 +24,7 @@ describe('checkAddresses', () => {
   })
 
   it('All unavailable IDs', async () => {
-    const addressesValidation = await checkAddresses('insert', bddMock.map(({_id, ...addr}) => addr))
+    const addressesValidation = await checkAddresses(bddMock.map(({_id, ...addr}) => addr), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -33,7 +33,7 @@ describe('checkAddresses', () => {
   })
 
   it('Some unavailable IDs', async () => {
-    const addressesValidation = await checkAddresses('insert', [...addressMock, ...bddMock].map(({_id, ...addr}) => addr))
+    const addressesValidation = await checkAddresses([...addressMock, ...bddMock].map(({_id, ...addr}) => addr), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -41,8 +41,15 @@ describe('checkAddresses', () => {
     bddMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Available IDs', async () => {
-    const addressesValidation = await checkAddresses('insert', addressMock)
+  it('Available IDs on Insert', async () => {
+    const addressesValidation = await checkAddresses(addressMock, 'insert')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(true)
+  })
+
+  it('Available IDs on Update', async () => {
+    const addressesValidation = await checkAddresses(addressMock, 'update')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)


### PR DESCRIPTION
Cette PR va ajouter 1 nouvelle route, pour la mise à jour d'adresses, à l'API de BAN-Platform :

_**A noter** : Actuellement, les traitements de données se font sur une collection indépendante, nommée address_test_

Les tests peuvent être lancés via la commande :

```sh
yarn test
```

**A noter :**
_Cette route nécessite un token de connexion de 36 caractères, qui doit, au préalable, être renseignés sur la variable d'environnement `BAN_API_AUTHORIZED_TOKENS` et passé en 'en-tête' lors de l'appel à la route (`Authorization: token MON_TOKEN_DE_36_CARACTERES_xxxxxxxxx`)._ 
_Un token peut être généré localement en passant la commande `npx nanoid --alphabet 123456789ABCDEFGHJKMNPQRSTVWXYZ --size 36` dans un terminal (cette commande nécessite la présence de `npm`)_

### PUT > /address/
Mise à jour d'adresses. 

**Exemple de valeurs attendu en entrée :**
```json
[
  {
    "id": "00000000-0000-4fff-9fff-00000000000a", // Cette ID doit être présent dans la base
    "codeCommune": "12345",
    "voieLabel": "Rue de la baleine",
    "numero": 1,
  }
]
```   

**Retour :** Renvoie un Identifiant d'état, à utiliser avec la route d'extraction d'états.
