### PR TITLE
Added new api DELETE route for unitary address

### DIFF
--- a/lib/api/address/models.js
+++ b/lib/api/address/models.js
@@ -29,6 +29,10 @@ export async function updateAddresses(addresses) {
   return mongo.db.collection(COLLECTION_ADDRESS).bulkWrite(bulkOperations)
 }
 
+export async function deleteAddress(addressID) {
+  return mongo.db.collection(COLLECTION_ADDRESS).deleteOne({id: addressID})
+}
+
 export async function getAdressJobStatus(statusID) {
   return mongo.db.collection(COLLECTION_JOB_STATUS).findOne({id: statusID})
 }

--- a/lib/api/address/routes.js
+++ b/lib/api/address/routes.js
@@ -3,7 +3,7 @@ import {customAlphabet} from 'nanoid'
 import express from 'express'
 import queue from '../../util/queue.cjs'
 import auth from '../../middleware/auth.js'
-import {getAddress, getAdressJobStatus} from './models.js'
+import {getAddress, deleteAddress, getAdressJobStatus} from './models.js'
 
 dotenv.config()
 const addressQueue = queue('address')
@@ -95,6 +95,36 @@ app.put('/', auth, async (req, res) => {
       date: new Date(),
       status: 'error',
       message: error,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
+app.delete('/:addressID', async (req, res) => {
+  let response
+  try {
+    const {addressID} = req.params
+    const address = await getAddress(addressID)
+
+    if (!address) {
+      res.status(404).send('Request ID unknown')
+      return
+    }
+
+    await deleteAddress(addressID)
+    response = {
+      date: new Date(),
+      status: 'success',
+      response: {},
+    }
+  } catch (error) {
+    const {message} = error
+    response = {
+      date: new Date(),
+      status: 'error',
+      message,
       response: {},
     }
   }


### PR DESCRIPTION
This pull request aims to add a new route to be able to delete an address with its ID.

Request : DELETE API_BASE_URL/address/{addressID}

The api will check if the ID is existing. If existing, it will try to delete it. If not, it will throw a 404 error ('Request ID unknown')