### PR TITLE
Fixed scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "compose": "node lib/compose/cli.cjs",
     "lint": "xo",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "worker": "node worker.cjs",
-    "worker:dev": "npx nodemon worker.cjs",
-    "start": "node server.cjs",
-    "dev": "npx nodemon server.cjs"
+    "worker": "node worker.js",
+    "worker:dev": "npx nodemon worker.js",
+    "start": "node server.js",
+    "dev": "npx nodemon server.js"
   },
   "dependencies": {
     "@ban-team/validateur-bal": "^2.13.0",


### PR DESCRIPTION
Context : 

Scripts in package.json were referencing files that had a .cjs extension that are now in .js (because of the ESModule migration)

This pull request aims to correct the package.json file to reference the right files in the different scripts