### PR TITLE
Modified address schema for BanID api

### DIFF
--- a/lib/api/address/__mocks__/address-data-mock.js
+++ b/lib/api/address/__mocks__/address-data-mock.js
@@ -2,21 +2,45 @@ export const addressMock = [
   {
     id: '00000000-0000-4fff-9fff-00000000000a',
     codeCommune: '12345',
-    voieLabel: 'Rue de la baleine',
+    idVoie: '00000000-0000-4fff-9fff-00000000001a',
     numero: 1,
+    positions: [{
+      type: 'entrée',
+      geometry: {
+        type: 'Point',
+        coordinates: [1.23, 2.34]
+      }
+    }],
+    dateMAJ: '2023-04-12'
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
     codeCommune: '12345',
-    voieLabel: 'Rue de la baleine',
+    idVoie: '00000000-0000-4fff-9fff-00000000001a',
     numero: 1,
     suffixe: 'bis',
+    positions: [{
+      type: 'entrée',
+      geometry: {
+        type: 'Point',
+        coordinates: [1.24, 2.34]
+      }
+    }],
+    dateMAJ: '2023-04-12'
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000c',
     codeCommune: '12345',
-    voieLabel: 'Rue de la baleine',
+    idVoie: '00000000-0000-4fff-9fff-00000000001a',
     numero: 2,
+    positions: [{
+      type: 'entrée',
+      geometry: {
+        type: 'Point',
+        coordinates: [1.25, 2.34]
+      }
+    }],
+    dateMAJ: '2023-04-12'
   }
 ]
 
@@ -27,9 +51,17 @@ export const bddAddressMock = [
     },
     id: '00000000-0000-4fff-9fff-000000000000',
     codeCommune: '12345',
-    voieLabel: 'Rue du Renard',
+    idVoie: '00000000-0000-4fff-9fff-00000000001b',
     numero: 10,
     suffixe: 'ter',
+    positions: [{
+      type: 'entrée',
+      geometry: {
+        type: 'Point',
+        coordinates: [1.25, 2.34]
+      }
+    }],
+    dateMAJ: '2023-04-12'
   },
   {
     _id: {
@@ -37,8 +69,16 @@ export const bddAddressMock = [
     },
     id: '00000000-0000-4fff-9fff-000000000001',
     codeCommune: '12345',
-    voieLabel: 'Rue du Renard',
+    idVoie: '00000000-0000-4fff-9fff-00000000001b',
     numero: 15,
+    positions: [{
+      type: 'entrée',
+      geometry: {
+        type: 'Point',
+        coordinates: [1.25, 2.34]
+      }
+    }],
+    dateMAJ: '2023-04-12'
   },
   {
     _id: {
@@ -46,7 +86,15 @@ export const bddAddressMock = [
     },
     id: '00000000-0000-4fff-9fff-000000000002',
     codeCommune: '12345',
-    voieLabel: 'Rue du Renard',
+    idVoie: '00000000-0000-4fff-9fff-00000000001b',
     numero: 6,
+    positions: [{
+      type: 'entrée',
+      geometry: {
+        type: 'Point',
+        coordinates: [1.25, 2.34]
+      }
+    }],
+    dateMAJ: '2023-04-12'
   }
 ]

--- a/lib/api/address/schema.js
+++ b/lib/api/address/schema.js
@@ -1,9 +1,26 @@
-import {object, string, number} from 'yup'
+import {object, string, number, boolean, array} from 'yup'
+
+const geometrySchema = object({
+  type: string().trim().matches(/^Point$/).required(),
+  coordinates: array().length(2).of(number()).required(),
+})
+
+const PositionTypes = ['entrée', 'bâtiment', 'cage d\'escalier', 'logement', 'service technique', 'délivrance postale', 'parcelle', 'segment', 'autre']
+
+const positionSchema = object({
+  type: string().trim().oneOf(PositionTypes).required(),
+  geometry: geometrySchema.required(),
+})
 
 export const banAddressSchema = object({
   id: string().trim().uuid().required(),
   codeCommune: string().trim().required(),
-  voieLabel: string().trim().required(),
-  numero: number().required().positive().integer(),
+  idVoie: string().trim().required(),
+  numero: number().positive().integer().required(),
   suffixe: string().trim(),
+  parcelles: array().of(string().trim()),
+  certifie: boolean(),
+  positions: array().of(positionSchema),
+  dateMAJ: string().trim().required(),
 })
+

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -57,7 +57,7 @@ describe('checkAddresses', () => {
   })
 
   it('Available addresses on Update', async () => {
-    const addressesValidation = await checkAddresses(bddAddressMock.map(addr => ({...addr, voieLabel: 'Rue de la mouette'})), 'update')
+    const addressesValidation = await checkAddresses(bddAddressMock.map(addr => ({...addr, certifie: true})), 'update')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)


### PR DESCRIPTION
Context : In order to complete the address schema on new banID api, we need to add the following fields : 

```
idVoie : string,
parcelles : string [],
certifie : boolean,
positions : Position [],
```

Specific types : 

```
Position : 
    geometry : {
        type: 'Point'
        coordinates: Coordinates
    },
    type: PositionType
```
```
Coordinates : [number, number]
```
```
PoisitionType : "entrée"|"bâtiment"|"cage d'escalier"|"logement"|"service technique"|"délivrance postale"|"parcelle"|"segment"|"autre"
```