### PR TITLE
Feature/ban platform api post multi delete

### DIFF
--- a/lib/api/address/models.js
+++ b/lib/api/address/models.js
@@ -24,10 +24,13 @@ export async function updateAddresses(addresses) {
       }
     }
   })
-  // TODO: Use status or historic collection for conserve event trace.
   return mongo.db.collection(COLLECTION_ADDRESS).bulkWrite(bulkOperations)
 }
 
 export async function deleteAddress(addressID) {
   return mongo.db.collection(COLLECTION_ADDRESS).deleteOne({id: addressID})
+}
+
+export async function deleteAddresses(addressIDs) {
+  return mongo.db.collection(COLLECTION_ADDRESS).deleteMany({id: {$in: addressIDs}})
 }

--- a/lib/api/address/routes.js
+++ b/lib/api/address/routes.js
@@ -131,4 +131,32 @@ app.delete('/:addressID', async (req, res) => {
   res.send(response)
 })
 
+app.post('/delete', auth, async (req, res) => {
+  let response
+  try {
+    const addressIDs = req.body
+    const statusID = nanoid()
+
+    await apiQueue.add(
+      {dataType: 'address', jobType: 'delete', data: addressIDs, statusID},
+      {jobId: statusID, removeOnComplete: true}
+    )
+    response = {
+      date: new Date(),
+      status: 'success',
+      message: `Check the status of your request : ${BAN_API_URL}/job-status/${statusID}`,
+      response: {statusID},
+    }
+  } catch (error) {
+    response = {
+      date: new Date(),
+      status: 'error',
+      message: error,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
 export default app

--- a/lib/api/address/schema.js
+++ b/lib/api/address/schema.js
@@ -12,8 +12,10 @@ const positionSchema = object({
   geometry: geometrySchema.required(),
 })
 
+export const banID = string().trim().uuid()
+
 export const banAddressSchema = object({
-  id: string().trim().uuid().required(),
+  id: banID.required(),
   codeCommune: string().trim().required(),
   idVoie: string().trim().required(),
   numero: number().positive().integer().required(),

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -72,28 +72,34 @@ const checkAddressesShema = async (err = 'Invalid format', addresses) => {
 }
 
 export const checkAddressesRequest = async (addresses, actionType) => {
-  let report
   const adresseIDs = addresses.map(address => address.id)
-
-  report = (
+  let report = (
     checkDataIsArray(`The request require an Array of address but receive ${typeof addresses}`, addresses)
     || checkDataIsNotEmptyArray('No address send to job', addresses)
   )
 
-  if (!report && actionType === 'insert') {
-    report = await checkIdsIsVacant('Unavailable IDs', adresseIDs)
+  if (!report) {
+    switch (actionType) {
+      case 'insert':
+        report = (
+          await checkIdsIsVacant('Unavailable IDs', adresseIDs)
+          || await checkAddressesShema('Invalid format', addresses)
+          || checkIdsIsUniq('Shared IDs in request', adresseIDs)
+          || dataValidationReportFrom(true)
+        )
+        break
+      case 'update':
+        report = (
+          await checkAddressesShema('Invalid format', addresses)
+          || checkIdsIsUniq('Shared IDs in request', adresseIDs)
+          || await checkIdsIsAvailable('Some unknow IDs', adresseIDs)
+          || dataValidationReportFrom(true)
+        )
+        break
+      default:
+        report = dataValidationReportFrom(false, 'Unknown action type', {actionType, addresses})
+    }
   }
 
-  if (!report && (actionType === 'insert' || actionType === 'update')) {
-    report = (
-      await checkAddressesShema('Invalid format', addresses)
-      || checkIdsIsUniq('Shared IDs in request', adresseIDs)
-    )
-  }
-
-  if (!report && actionType === 'update') {
-    report = await checkIdsIsAvailable('Some unknown IDs', adresseIDs)
-  }
-
-  return report || dataValidationReportFrom(true)
+  return report
 }

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -26,56 +26,74 @@ const banAddressValidation = async address => {
   return dataValidationReportFrom(true)
 }
 
-export const checkAddressesRequest = async (addresses, type) => {
+const checkDataIsArray = (err, data) => {
+  if (!Array.isArray(data)) {
+    return dataValidationReportFrom(false, err)
+  }
+}
+
+const checkDataIsNotEmptyArray = (err, data) => {
+  if (data.length === 0) {
+    return dataValidationReportFrom(false, err)
+  }
+}
+
+const checkIdsIsVacant = async (err = 'Unavailable IDs', adresseIDs) => {
+  const existingIDs = await getExistingIDs(adresseIDs)
+  if (existingIDs.length > 0) {
+    return dataValidationReportFrom(false, err, existingIDs)
+  }
+}
+
+const checkIdsIsAvailable = async (err = 'Some unknown IDs', adresseIDs) => {
+  const existingIDs = await getExistingIDs(adresseIDs)
+  if (existingIDs.length !== adresseIDs.length) {
+    return dataValidationReportFrom(false, err, adresseIDs.filter(id => !existingIDs.includes(id)))
+  }
+}
+
+const checkIdsIsUniq = (err = 'Shared IDs in request', adresseIDs) => {
+  const uniqAdresseIDs = [...new Set(adresseIDs)]
+  if (uniqAdresseIDs.length !== adresseIDs.length) {
+    const sharedIDs = Object.entries(adresseIDs.reduce((acc, id) => ({...acc, [id]: (acc?.[id] ?? 0) + 1}), {}))
+      .filter(([, nb]) => nb > 1)
+      .map(([id]) => id)
+    return dataValidationReportFrom(false, err, sharedIDs)
+  }
+}
+
+const checkAddressesShema = async (err = 'Invalid format', addresses) => {
+  const addressesValidationPromises = addresses.map(address => banAddressValidation(address))
+  const addressesValidation = await Promise.all(addressesValidationPromises)
+  const invalidAddresses = addressesValidation.filter(({isValid}) => !isValid)
+  if (invalidAddresses.length > 0) {
+    return dataValidationReportFrom(false, err, invalidAddresses)
+  }
+}
+
+export const checkAddressesRequest = async (addresses, actionType) => {
+  let report
   const adresseIDs = addresses.map(address => address.id)
 
-  if (adresseIDs.length === 0) {
-    return dataValidationReportFrom(false, 'No address send to job')
+  report = (
+    checkDataIsArray(`The request require an Array of address but receive ${typeof addresses}`, addresses)
+    || checkDataIsNotEmptyArray('No address send to job', addresses)
+  )
+
+  if (!report && actionType === 'insert') {
+    report = await checkIdsIsVacant('Unavailable IDs', adresseIDs)
   }
 
-  if (type === 'insert') {
-    // Check if IDs are already existing in BDD
-    const existingIDs = await getExistingIDs(adresseIDs)
-    if (existingIDs.length > 0) {
-      return dataValidationReportFrom(false, 'Unavailable IDs', existingIDs)
-    }
+  if (!report && (actionType === 'insert' || actionType === 'update')) {
+    report = (
+      await checkAddressesShema('Invalid format', addresses)
+      || checkIdsIsUniq('Shared IDs in request', adresseIDs)
+    )
   }
 
-  if (type === 'insert' || type === 'update') {
-  // Check address schema
-    const addressesValidationPromises = addresses.map(address => banAddressValidation(address))
-    const addressesValidation = await Promise.all(addressesValidationPromises)
-    const invalidAddresses = addressesValidation.filter(({isValid}) => !isValid)
-    if (invalidAddresses.length > 0) {
-      return dataValidationReportFrom(false, 'Invalid format', invalidAddresses)
-    }
-
-    // Check if IDs are uniq in the request
-    const uniqAdresseIDs = [...new Set(adresseIDs)]
-    if (uniqAdresseIDs.length !== adresseIDs.length) {
-      const sharedIDs = Object.entries(
-        addresses.reduce((acc, addr) => {
-          const key = addr.id
-          return {
-            ...acc,
-            [key]: [
-              ...acc[key] || [],
-              addr
-            ]
-          }
-        }, {})
-      ).reduce((acc, [key, values]) => (values.length > 1) ? [...acc, key] : acc, [])
-      return dataValidationReportFrom(false, 'Shared IDs in request', sharedIDs)
-    }
+  if (!report && actionType === 'update') {
+    report = await checkIdsIsAvailable('Some unknown IDs', adresseIDs)
   }
 
-  if (type === 'update') {
-    // Check if IDs are already existing in BDD
-    const existingIDs = await getExistingIDs(adresseIDs)
-    if (existingIDs.length !== adresseIDs.length) {
-      return dataValidationReportFrom(false, 'Some unknown IDs', adresseIDs.filter(id => !existingIDs.includes(id)))
-    }
-  }
-
-  return dataValidationReportFrom(true)
+  return report || dataValidationReportFrom(true)
 }

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -1,5 +1,5 @@
 import {getAddresses} from './models.js'
-import {banAddressSchema} from './schema.js'
+import {banAddressSchema, banID} from './schema.js'
 
 const dataValidationReportFrom = (isValid, message, data) => ({
   isValid,
@@ -26,6 +26,16 @@ const banAddressValidation = async address => {
   return dataValidationReportFrom(true)
 }
 
+const banAddressIdValidation = async addressID => {
+  try {
+    await banID.validate(addressID, {abortEarly: false})
+  } catch (error) {
+    return dataValidationReportFrom(false, `Invalid ID format (id: ${addressID})`, error.errors)
+  }
+
+  return dataValidationReportFrom(true)
+}
+
 const checkDataIsArray = (err, data) => {
   if (!Array.isArray(data)) {
     return dataValidationReportFrom(false, err)
@@ -46,9 +56,10 @@ const checkIdsIsVacant = async (err = 'Unavailable IDs', adresseIDs) => {
 }
 
 const checkIdsIsAvailable = async (err = 'Some unknown IDs', adresseIDs) => {
-  const existingIDs = await getExistingIDs(adresseIDs)
-  if (existingIDs.length !== adresseIDs.length) {
-    return dataValidationReportFrom(false, err, adresseIDs.filter(id => !existingIDs.includes(id)))
+  const unduplicateAdresseIDs = [...new Set(adresseIDs)]
+  const existingIDs = await getExistingIDs(unduplicateAdresseIDs)
+  if (existingIDs.length !== unduplicateAdresseIDs.length) {
+    return dataValidationReportFrom(false, err, unduplicateAdresseIDs.filter(id => !existingIDs.includes(id)))
   }
 }
 
@@ -62,7 +73,7 @@ const checkIdsIsUniq = (err = 'Shared IDs in request', adresseIDs) => {
   }
 }
 
-const checkAddressesShema = async (err = 'Invalid format', addresses) => {
+const checkAddressesShema = async (err = 'Invalid addresses format', addresses) => {
   const addressesValidationPromises = addresses.map(address => banAddressValidation(address))
   const addressesValidation = await Promise.all(addressesValidationPromises)
   const invalidAddresses = addressesValidation.filter(({isValid}) => !isValid)
@@ -71,34 +82,76 @@ const checkAddressesShema = async (err = 'Invalid format', addresses) => {
   }
 }
 
-export const checkAddressesRequest = async (addresses, actionType) => {
-  const adresseIDs = addresses.map(address => address.id)
-  let report = (
-    checkDataIsArray(`The request require an Array of address but receive ${typeof addresses}`, addresses)
-    || checkDataIsNotEmptyArray('No address send to job', addresses)
-  )
+const checkAddressesIdsShema = async (err = 'Invalid IDs format', adresseIDs) => {
+  const addressIdsValidationPromises = adresseIDs.map(id => banAddressIdValidation(id))
+  const addressIdsValidation = await Promise.all(addressIdsValidationPromises)
+  const invalidAddressIds = addressIdsValidation.filter(({isValid}) => !isValid)
+  if (invalidAddressIds.length > 0) {
+    return dataValidationReportFrom(false, err, invalidAddressIds)
+  }
+}
+
+const checkDataFormat = (arrayError, emptyError, data) => (
+  checkDataIsArray(arrayError, data)
+  || checkDataIsNotEmptyArray(emptyError, data)
+)
+
+const checkAddressesIDsRequest = async (adresseIDs, actionType, defaultReturn = true) => {
+  let report = checkDataFormat(
+    `The request require an Array of address IDs but receive ${typeof adresseIDs}`,
+    'No address ID send to job',
+    adresseIDs
+  ) || await checkAddressesIdsShema('Invalid IDs format', adresseIDs)
 
   if (!report) {
     switch (actionType) {
       case 'insert':
         report = (
-          await checkIdsIsVacant('Unavailable IDs', adresseIDs)
-          || await checkAddressesShema('Invalid format', addresses)
-          || checkIdsIsUniq('Shared IDs in request', adresseIDs)
+          checkIdsIsUniq('Shared IDs in request', adresseIDs)
+          || await checkIdsIsVacant('Unavailable IDs', adresseIDs)
           || dataValidationReportFrom(true)
         )
         break
       case 'update':
         report = (
-          await checkAddressesShema('Invalid format', addresses)
-          || checkIdsIsUniq('Shared IDs in request', adresseIDs)
-          || await checkIdsIsAvailable('Some unknow IDs', adresseIDs)
+          checkIdsIsUniq('Shared IDs in request', adresseIDs)
+          || await checkIdsIsAvailable('Some unknown IDs', adresseIDs)
+          || dataValidationReportFrom(true)
+
+        )
+        break
+      case 'delete':
+        report = (
+          checkIdsIsUniq('Shared IDs in request', adresseIDs)
+          || await checkIdsIsAvailable('Some unknown IDs', adresseIDs)
           || dataValidationReportFrom(true)
         )
         break
       default:
-        report = dataValidationReportFrom(false, 'Unknown action type', {actionType, addresses})
+        report = dataValidationReportFrom(false, 'Unknown action type', {actionType, adresseIDs})
     }
+  }
+
+  return report || (defaultReturn && dataValidationReportFrom(true)) || null
+}
+
+export const checkAddressesRequest = async (addresses, actionType) => {
+  let report
+
+  switch (actionType) {
+    case 'insert':
+    case 'update':
+      report = checkDataFormat(
+        `The request require an Array of address but receive ${typeof addresses}`,
+        'No address send to job',
+        addresses
+      )
+        || await checkAddressesIDsRequest(addresses.map(address => address.id), actionType, false)
+        || await checkAddressesShema('Invalid format', addresses)
+        || dataValidationReportFrom(true)
+      break
+    default:
+      report = dataValidationReportFrom(false, 'Unknown action type', {actionType, addresses})
   }
 
   return report

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -1,7 +1,7 @@
 import {getAddresses} from './models.js'
 import {banAddressSchema, banID} from './schema.js'
 
-const dataValidationReportFrom = (isValid, message, data) => ({
+export const dataValidationReportFrom = (isValid, message, data) => ({
   isValid,
   ...(message || data ? {
     report: {
@@ -96,7 +96,7 @@ const checkDataFormat = (arrayError, emptyError, data) => (
   || checkDataIsNotEmptyArray(emptyError, data)
 )
 
-const checkAddressesIDsRequest = async (adresseIDs, actionType, defaultReturn = true) => {
+export const checkAddressesIDsRequest = async (adresseIDs, actionType, defaultReturn = true) => {
   let report = checkDataFormat(
     `The request require an Array of address IDs but receive ${typeof adresseIDs}`,
     'No address ID send to job',

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -1,7 +1,7 @@
 import {getAddresses} from './models.js'
 import {banAddressSchema} from './schema.js'
 
-const report = (isValid, message, data) => ({
+const dataValidationReportFrom = (isValid, message, data) => ({
   isValid,
   ...(message || data ? {
     report: {
@@ -20,24 +20,24 @@ const banAddressValidation = async address => {
   try {
     await banAddressSchema.validate(address, {abortEarly: false})
   } catch (error) {
-    return report(false, `Invalid address format (id: ${address.id})`, error.errors)
+    return dataValidationReportFrom(false, `Invalid address format (id: ${address.id})`, error.errors)
   }
 
-  return report(true)
+  return dataValidationReportFrom(true)
 }
 
-export const checkAddresses = async (addresses, type) => {
+export const checkAddressesRequest = async (addresses, type) => {
   const adresseIDs = addresses.map(address => address.id)
 
   if (adresseIDs.length === 0) {
-    return report(false, 'No address send to job')
+    return dataValidationReportFrom(false, 'No address send to job')
   }
 
   if (type === 'insert') {
     // Check if IDs are already existing in BDD
     const existingIDs = await getExistingIDs(adresseIDs)
     if (existingIDs.length > 0) {
-      return report(false, 'Unavailable IDs', existingIDs)
+      return dataValidationReportFrom(false, 'Unavailable IDs', existingIDs)
     }
   }
 
@@ -47,7 +47,7 @@ export const checkAddresses = async (addresses, type) => {
     const addressesValidation = await Promise.all(addressesValidationPromises)
     const invalidAddresses = addressesValidation.filter(({isValid}) => !isValid)
     if (invalidAddresses.length > 0) {
-      return report(false, 'Invalid format', invalidAddresses)
+      return dataValidationReportFrom(false, 'Invalid format', invalidAddresses)
     }
 
     // Check if IDs are uniq in the request
@@ -65,7 +65,7 @@ export const checkAddresses = async (addresses, type) => {
           }
         }, {})
       ).reduce((acc, [key, values]) => (values.length > 1) ? [...acc, key] : acc, [])
-      return report(false, 'Shared IDs in request', sharedIDs)
+      return dataValidationReportFrom(false, 'Shared IDs in request', sharedIDs)
     }
   }
 
@@ -73,9 +73,9 @@ export const checkAddresses = async (addresses, type) => {
     // Check if IDs are already existing in BDD
     const existingIDs = await getExistingIDs(adresseIDs)
     if (existingIDs.length !== adresseIDs.length) {
-      return report(false, 'Some unknown IDs', adresseIDs.filter(id => !existingIDs.includes(id)))
+      return dataValidationReportFrom(false, 'Some unknown IDs', adresseIDs.filter(id => !existingIDs.includes(id)))
     }
   }
 
-  return report(true)
+  return dataValidationReportFrom(true)
 }

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -3,7 +3,7 @@ import {object, string, bool, array} from 'yup'
 import {addressMock, bddAddressMock} from './__mocks__/address-data-mock.js'
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/address-models.js'))
-const {checkAddresses} = await import('./utils.js')
+const {checkAddressesRequest} = await import('./utils.js')
 
 const addressesValidationSchema = object({
   isValid: bool().required(),
@@ -13,10 +13,10 @@ const addressesValidationSchema = object({
   }),
 })
 
-describe('checkAddresses', () => {
+describe('checkAddressesRequest', () => {
   it('Shared  IDs', async () => {
     const sharedID = '00000000-0000-4fff-9fff-aaaaaaaaaaaa'
-    const addressesValidation = await checkAddresses(addressMock.map(addr => ({...addr, id: sharedID})), 'insert')
+    const addressesValidation = await checkAddressesRequest(addressMock.map(addr => ({...addr, id: sharedID})), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -24,7 +24,7 @@ describe('checkAddresses', () => {
   })
 
   it('All unavailable IDs', async () => {
-    const addressesValidation = await checkAddresses(bddAddressMock.map(({_id, ...addr}) => addr), 'insert')
+    const addressesValidation = await checkAddressesRequest(bddAddressMock.map(({_id, ...addr}) => addr), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -33,7 +33,7 @@ describe('checkAddresses', () => {
   })
 
   it('Some unavailable IDs', async () => {
-    const addressesValidation = await checkAddresses([...addressMock, ...bddAddressMock].map(({_id, ...addr}) => addr), 'insert')
+    const addressesValidation = await checkAddressesRequest([...addressMock, ...bddAddressMock].map(({_id, ...addr}) => addr), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -42,14 +42,14 @@ describe('checkAddresses', () => {
   })
 
   it('Available addresses and IDs on Insert', async () => {
-    const addressesValidation = await checkAddresses(addressMock, 'insert')
+    const addressesValidation = await checkAddressesRequest(addressMock, 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)
   })
 
   it('Unknown IDs on Update', async () => {
-    const addressesValidation = await checkAddresses(addressMock, 'update')
+    const addressesValidation = await checkAddressesRequest(addressMock, 'update')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(false)
@@ -57,7 +57,7 @@ describe('checkAddresses', () => {
   })
 
   it('Available addresses on Update', async () => {
-    const addressesValidation = await checkAddresses(bddAddressMock.map(addr => ({...addr, certifie: true})), 'update')
+    const addressesValidation = await checkAddressesRequest(bddAddressMock.map(addr => ({...addr, certifie: true})), 'update')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -3,7 +3,7 @@ import {object, string, bool, array} from 'yup'
 import {addressMock, bddAddressMock} from './__mocks__/address-data-mock.js'
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/address-models.js'))
-const {checkAddressesRequest} = await import('./utils.js')
+const {checkAddressesIDsRequest, checkAddressesRequest} = await import('./utils.js')
 
 const addressesValidationSchema = object({
   isValid: bool().required(),
@@ -13,8 +13,45 @@ const addressesValidationSchema = object({
   }),
 })
 
+describe('checkAddressesIDsRequest', () => {
+  it('Unavailable IDs on insert', async () => {
+    const addressesValidation = await checkAddressesIDsRequest(bddAddressMock.map(({id}) => id), 'insert')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    expect(addressesValidation?.report?.data).toEqual(bddAddressMock.map(({id}) => id))
+  })
+
+  it('Shared IDs on delete', async () => {
+    const sharedID = bddAddressMock[0].id
+    const addressesValidation = await checkAddressesIDsRequest(bddAddressMock.map(({id}, i) => i < 2 ? sharedID : id), 'delete')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    expect(addressesValidation?.report?.data).toEqual([sharedID])
+  })
+
+  it('All unkown IDs', async () => {
+    const addressesValidation = await checkAddressesIDsRequest(addressMock.map(({id}) => id), 'delete')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    expect(addressesValidation?.report?.data).toEqual(addressMock.map(({id}) => id))
+    addressMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Some unkown IDs', async () => {
+    const addressesValidation = await checkAddressesIDsRequest([...addressMock, ...bddAddressMock].map(({id}) => id), 'delete')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    expect(addressesValidation?.report?.data).toEqual(addressMock.map(({id}) => id))
+    addressMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
+  })
+})
+
 describe('checkAddressesRequest', () => {
-  it('Shared  IDs', async () => {
+  it('Shared IDs', async () => {
     const sharedID = '00000000-0000-4fff-9fff-aaaaaaaaaaaa'
     const addressesValidation = await checkAddressesRequest(addressMock.map(addr => ({...addr, id: sharedID})), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})

--- a/lib/api/consumers/api-consumer.js
+++ b/lib/api/consumers/api-consumer.js
@@ -1,6 +1,6 @@
 import {setJobStatus} from '../job-status/models.js'
-import {setAddresses, updateAddresses} from '../address/models.js'
-import {checkAddressesRequest} from '../address/utils.js'
+import {setAddresses, updateAddresses, deleteAddresses} from '../address/models.js'
+import {checkAddressesRequest, checkAddressesIDsRequest, dataValidationReportFrom} from '../address/utils.js'
 import {setRoads, updateRoads} from '../road/models.js'
 import {checkRoadsRequest} from '../road/utils.js'
 
@@ -29,16 +29,31 @@ export default async function apiConsumers({data: {dataType, jobType, data, stat
   done()
 }
 
-const addressConsumer = async (jobType, addresses, statusID) => {
-  const addressesCount = addresses.length
-  const dataAddressesValidationReport = await checkAddressesRequest(addresses, jobType)
-  if (dataAddressesValidationReport.isValid) {
+const addressConsumer = async (jobType, payload, statusID) => {
+  const checkRequestData = async (payload, jobType) => {
     switch (jobType) {
       case 'insert':
-        await setAddresses(addresses)
+      case 'update':
+        return checkAddressesRequest(payload, jobType)
+      case 'delete':
+        return checkAddressesIDsRequest(payload, jobType)
+      default:
+        return dataValidationReportFrom(false, 'Unknown action type', {actionType: jobType, payload})
+    }
+  }
+
+  const requestDataValidationReport = await checkRequestData(payload, jobType)
+  const addressesCount = payload.length
+  if (requestDataValidationReport.isValid) {
+    switch (jobType) {
+      case 'insert':
+        await setAddresses(payload)
         break
       case 'update':
-        await updateAddresses(addresses)
+        await updateAddresses(payload)
+        break
+      case 'delete':
+        await deleteAddresses(payload)
         break
       default:
         console.warn(`Address Consumer Warn: Unknown job type : '${jobType}'`)
@@ -57,7 +72,7 @@ const addressConsumer = async (jobType, addresses, statusID) => {
       jobType,
       count: addressesCount,
       message: 'addresses are not valid',
-      report: dataAddressesValidationReport.report,
+      report: requestDataValidationReport.report,
     })
   }
 }

--- a/lib/api/consumers/api-consumer.js
+++ b/lib/api/consumers/api-consumer.js
@@ -2,7 +2,7 @@ import {setJobStatus} from '../job-status/models.js'
 import {setAddresses, updateAddresses} from '../address/models.js'
 import {checkAddressesRequest} from '../address/utils.js'
 import {setRoads, updateRoads} from '../road/models.js'
-import {checkRoads} from '../road/utils.js'
+import {checkRoadsRequest} from '../road/utils.js'
 
 export default async function apiConsumers({data: {dataType, jobType, data, statusID}}, done) {
   try {
@@ -31,8 +31,8 @@ export default async function apiConsumers({data: {dataType, jobType, data, stat
 
 const addressConsumer = async (jobType, addresses, statusID) => {
   const addressesCount = addresses.length
-  const addressesValidation = await checkAddressesRequest(addresses, jobType)
-  if (addressesValidation.isValid) {
+  const dataAddressesValidationReport = await checkAddressesRequest(addresses, jobType)
+  if (dataAddressesValidationReport.isValid) {
     switch (jobType) {
       case 'insert':
         await setAddresses(addresses)
@@ -57,15 +57,15 @@ const addressConsumer = async (jobType, addresses, statusID) => {
       jobType,
       count: addressesCount,
       message: 'addresses are not valid',
-      report: addressesValidation.report,
+      report: dataAddressesValidationReport.report,
     })
   }
 }
 
 const roadConsumer = async (jobType, roads, statusID) => {
   const roadsCount = roads.length
-  const roadValidation = await checkRoads(roads, jobType)
-  if (roadValidation.isValid) {
+  const dataRoadValidationReport = await checkRoadsRequest(roads, jobType)
+  if (dataRoadValidationReport.isValid) {
     switch (jobType) {
       case 'insert':
         await setRoads(roads)
@@ -90,7 +90,7 @@ const roadConsumer = async (jobType, roads, statusID) => {
       jobType,
       count: roadsCount,
       message: 'roads are not valid',
-      report: roadValidation.report,
+      report: dataRoadValidationReport.report,
     })
   }
 }

--- a/lib/api/consumers/api-consumer.js
+++ b/lib/api/consumers/api-consumer.js
@@ -1,6 +1,6 @@
 import {setJobStatus} from '../job-status/models.js'
 import {setAddresses, updateAddresses} from '../address/models.js'
-import {checkAddresses} from '../address/utils.js'
+import {checkAddressesRequest} from '../address/utils.js'
 import {setRoads, updateRoads} from '../road/models.js'
 import {checkRoads} from '../road/utils.js'
 
@@ -31,7 +31,7 @@ export default async function apiConsumers({data: {dataType, jobType, data, stat
 
 const addressConsumer = async (jobType, addresses, statusID) => {
   const addressesCount = addresses.length
-  const addressesValidation = await checkAddresses(addresses, jobType)
+  const addressesValidation = await checkAddressesRequest(addresses, jobType)
   if (addressesValidation.isValid) {
     switch (jobType) {
       case 'insert':

--- a/lib/api/road/utils.js
+++ b/lib/api/road/utils.js
@@ -26,7 +26,7 @@ const banRoadValidation = async road => {
   return report(true)
 }
 
-export const checkRoads = async (roads, type) => {
+export const checkRoadsRequest = async (roads, type) => {
   const roadIDs = roads.map(road => road.id)
 
   if (roadIDs.length === 0) {

--- a/lib/api/road/utils.spec.js
+++ b/lib/api/road/utils.spec.js
@@ -3,7 +3,7 @@ import {object, string, bool, array} from 'yup'
 import {roadMock, bddRoadMock} from './__mocks__/road-data-mock.js'
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/road-models.js'))
-const {checkRoads} = await import('./utils.js')
+const {checkRoadsRequest} = await import('./utils.js')
 
 const roadsValidationSchema = object({
   isValid: bool().required(),
@@ -13,10 +13,10 @@ const roadsValidationSchema = object({
   }),
 })
 
-describe('checkRoads', () => {
+describe('checkRoadsRequest', () => {
   it('Shared  IDs', async () => {
     const sharedID = '00000000-0000-4fff-9fff-aaaaaaaaaaaa'
-    const roadsValidation = await checkRoads(roadMock.map(road => ({...road, id: sharedID})), 'insert')
+    const roadsValidation = await checkRoadsRequest(roadMock.map(road => ({...road, id: sharedID})), 'insert')
     const testSchema = await roadsValidationSchema.isValid(roadsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(roadsValidation?.isValid).toBe(false)
@@ -24,7 +24,7 @@ describe('checkRoads', () => {
   })
 
   it('All unavailable IDs', async () => {
-    const roadsValidation = await checkRoads(bddRoadMock.map(({_id, ...road}) => road), 'insert')
+    const roadsValidation = await checkRoadsRequest(bddRoadMock.map(({_id, ...road}) => road), 'insert')
     const testSchema = await roadsValidationSchema.isValid(roadsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(roadsValidation?.isValid).toBe(false)
@@ -33,7 +33,7 @@ describe('checkRoads', () => {
   })
 
   it('Some unavailable IDs', async () => {
-    const roadsValidation = await checkRoads([...roadMock, ...bddRoadMock].map(({_id, ...road}) => road), 'insert')
+    const roadsValidation = await checkRoadsRequest([...roadMock, ...bddRoadMock].map(({_id, ...road}) => road), 'insert')
     const testSchema = await roadsValidationSchema.isValid(roadsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(roadsValidation?.isValid).toBe(false)
@@ -42,14 +42,14 @@ describe('checkRoads', () => {
   })
 
   it('Available roads and IDs on Insert', async () => {
-    const roadsValidation = await checkRoads(roadMock, 'insert')
+    const roadsValidation = await checkRoadsRequest(roadMock, 'insert')
     const testSchema = await roadsValidationSchema.isValid(roadsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(roadsValidation?.isValid).toBe(true)
   })
 
   it('Unknown IDs on Update', async () => {
-    const roadsValidation = await checkRoads(roadMock, 'update')
+    const roadsValidation = await checkRoadsRequest(roadMock, 'update')
     const testSchema = await roadsValidationSchema.isValid(roadsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(roadsValidation?.isValid).toBe(false)
@@ -57,7 +57,7 @@ describe('checkRoads', () => {
   })
 
   it('Available roads on Update', async () => {
-    const roadsValidation = await checkRoads(bddRoadMock.map(road => ({...road, voieLabel: 'Rue de la mouette'})), 'update')
+    const roadsValidation = await checkRoadsRequest(bddRoadMock.map(road => ({...road, voieLabel: 'Rue de la mouette'})), 'update')
     const testSchema = await roadsValidationSchema.isValid(roadsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(roadsValidation?.isValid).toBe(true)


### PR DESCRIPTION
Cette PR va ajouter 2 nouvelles routes, pour la mise à jour et la suppression d'adresses, à l'API de BAN-Platform :

_**A noter** : Actuellement, les traitements de données se font sur une collection indépendante, nommée address_test_

Les tests peuvent être lancés via la commande :

```sh
yarn test
```

**A noter :**
_Cette route nécessite un token de connexion de 36 caractères, qui doit, au préalable, être renseignés sur la variable d'environnement `BAN_API_AUTHORIZED_TOKENS` et passé en 'en-tête' lors de l'appel à la route (`Authorization: token MON_TOKEN_DE_36_CARACTERES_xxxxxxxxx`)._ 
_Un token peut être généré localement en passant la commande `npx nanoid --alphabet 123456789ABCDEFGHJKMNPQRSTVWXYZ --size 36` dans un terminal (cette commande nécessite la présence de `npm`)_

### POST > /address/delete
Suppression d'un ensemble d'adresses. 

**Exemple de valeurs attendu en entrée :**
```json
[
"00000000-0000-4fff-9fff-00000000000a",
"00000000-0000-4fff-9fff-00000000000b", 
] // Ces IDs doivent être présent dans la base
```   

**Retour :** Renvoie un Identifiant d'état, à utiliser avec la route d'extraction d'états.
