### PR TITLE
Fix test script for cross env

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "type":"module",
+  "type": "module",
   "scripts": {
     "apply-batch-certification": "node scripts/apply-batch-certification.cjs",
     "prepare-contours": "node scripts/prepare-contours.cjs",
@@ -20,18 +20,18 @@
     "dist": "node lib/distribute/cli.cjs",
     "compose": "node lib/compose/cli.cjs",
     "lint": "xo",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "worker": "node worker.js",
     "worker:dev": "npx nodemon worker.js",
     "start": "node server.js",
     "dev": "npx nodemon server.js"
   },
   "dependencies": {
+    "@ban-team/fantoir": "^0.15.0",
+    "@ban-team/gazetteer": "^2.0.0",
     "@ban-team/validateur-bal": "^2.13.0",
     "@etalab/adresses-util": "^0.8.2",
     "@etalab/decoupage-administratif": "^3.0.0",
-    "@ban-team/fantoir": "^0.15.0",
-    "@ban-team/gazetteer": "^2.0.0",
     "@etalab/majic": "^0.11.0",
     "@etalab/normadresse": "^1.2.0",
     "@etalab/project-legal": "^0.6.0",
@@ -78,6 +78,7 @@
     "yup": "^1.0.2"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "jest": "^29.5.0",
     "xo": "^0.50.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3697,7 +3697,14 @@ cron-parser@^2.13.0:
     is-nan "^1.3.0"
     moment-timezone "^0.5.31"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Context : Windows command prompt is crashing when meeting environment variables set this way : NODE_OPTIONS=--experimental-vm-modules.

Action : In order to solve the issue, the "cross-env" package has been installed and added to the "test" script : 

`"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"`