### PR TITLE
correction code idVoie trouvé non exploité

### DIFF
--- a/lib/compose/processors/recompute-codes-voies.cjs
+++ b/lib/compose/processors/recompute-codes-voies.cjs
@@ -30,12 +30,9 @@ async function recomputeCodesVoies(adressesCommune) {
 
       if (fantoir) {
         // Avant de renvoyer les adresses on remplit l'idVoie trouvé
-        const idVoieFound = fantoir.successeur?.replace('-', '_') || fantoir.codeCommune + '_' + fantoir.codeFantoir
-        for (const adresse of adresses) {
-          adresse.idVoie = idVoieFound
-        }
-
-        return {adresses, fantoir, idVoie: fantoir.successeur?.replace('-', '_') || `${fantoir.codeCommune}_${fantoir.codeFantoir}`}
+        const idVoie = fantoir.successeur?.replace('-', '_') || fantoir.codeCommune + '_' + fantoir.codeFantoir
+        const adressesWIDV = adresses.map(adresse => ({...adresse, idVoie}))
+        return {adressesWIDV, fantoir, idVoie}
       }
 
       return {adresses}

--- a/lib/compose/processors/recompute-codes-voies.cjs
+++ b/lib/compose/processors/recompute-codes-voies.cjs
@@ -29,6 +29,12 @@ async function recomputeCodesVoies(adressesCommune) {
       const fantoir = findVoie(adresse.nomVoie, adresse.codeAncienneCommune)
 
       if (fantoir) {
+        // Avant de renvoyer les adresses on remplit l'idVoie trouvé
+        const idVoieFound = fantoir.successeur?.replace('-', '_') || fantoir.codeCommune + '_' + fantoir.codeFantoir
+        for (const adresse of adresses) {
+          adresse.idVoie = idVoieFound
+        }
+
         return {adresses, fantoir, idVoie: fantoir.successeur?.replace('-', '_') || `${fantoir.codeCommune}_${fantoir.codeFantoir}`}
       }
 


### PR DESCRIPTION
pour le problème d'orthez.

on passe par composeCommune (ban-plateforme\lib\compose\index.cjs)
puis dans const balData = isBAL && await getBalData(codeCommune, currentRevision)

la function getBalData appelle prepareData qui appelle recomputeCodesVoies

-> cette function permet de retrouver le code de voie (idVoie) 
-> or il n'était pas reporté sur les adresses. **(cf ajout de code de la PR)**
Mais de retour dans index.cjs on passe dans buildVoies (ban-plateforme\lib\compose\strategies\bal\voies.cjs) qui appelle computeGroups et se sert de l'idVoie. (il n'était pas remplit dans les adresses alors qu'on en avait trouvé un).

-> résultat dans la BAN actuelle  db.voies.find({codeCommune : '64430', nomVoie: 'Rue De Labestaa'}).pretty() -> 2 voies.
-> en local si on lance le compose de la commune 64430 on obtient maintenant une seule voie : 

        "_id" : ObjectId("64427d28c02791782ea14750"),
        "type" : "voie",
        "groupId" : "fantoir-64430_0411",
        "idVoie" : "64430_0411",
        "idVoieFantoir" : "64430_0411",
        "nomVoie" : "Rue De Labestaa",

idem pour les autres voies.

fix #127