### PR TITLE
Added watch behavior for docker implementation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,10 @@ services:
     volumes:
       - data:/app/data
       - dist:/app/dist
-
+      - ./lib:/app/lib
+      - ./scripts:/app/scripts
+      - ./server.js:/app/server.js
+      - ./worker.js:/app/worker.js
 volumes:
   data:
   dist:

--- a/process.dev.yml
+++ b/process.dev.yml
@@ -2,6 +2,8 @@ apps:
   - name : 'ban-api'
     script : 'server.js'
     instances: '1'
+    watch: true
   - name : 'ban-worker'
     script : 'worker.js'
     instances: '1'
+    watch: true


### PR DESCRIPTION
I. Context : 
When ban-plateforme is running (worker and server) and code is modified during local development, the docker container has to be restarted to take the changes into account.

II. Enhancement : 
This pull request adds the watch behavior on code that is part of the following folder and file list : 
- lib (folder)
- scripts (folder)
- server.js (file)
- worker.js (file)

III. How to test : 
- Launch the docker containers by starting the following command : 
`docker-compose up --build -d`

- Modify the code and see if the worker or/and the server is restarted in the 'api' terminal container