### PR TITLE
création commande de composition "ramasse miette"

### DIFF
--- a/lib/compose/bal-garbage-collector/__mocks__/api-depot-mock.js
+++ b/lib/compose/bal-garbage-collector/__mocks__/api-depot-mock.js
@@ -1,0 +1,3 @@
+import {currentRevisionsMock} from './revision-data-mock.js'
+
+export const getCurrentRevisons = () => (currentRevisionsMock)

--- a/lib/compose/bal-garbage-collector/__mocks__/compose-mock.js
+++ b/lib/compose/bal-garbage-collector/__mocks__/compose-mock.js
@@ -1,0 +1,3 @@
+export const composeCommune = async codeCommune => (codeCommune)
+
+export default composeCommune

--- a/lib/compose/bal-garbage-collector/__mocks__/models-mock.js
+++ b/lib/compose/bal-garbage-collector/__mocks__/models-mock.js
@@ -1,0 +1,3 @@
+import {bddCommuneMock} from './revision-data-mock.js'
+
+export const getCommuneRevisionID = () => (bddCommuneMock)

--- a/lib/compose/bal-garbage-collector/__mocks__/revision-data-mock.js
+++ b/lib/compose/bal-garbage-collector/__mocks__/revision-data-mock.js
@@ -1,0 +1,50 @@
+export const currentRevisionsMock = [
+  {
+    _id: '6450d6e66ba2e9f7769df7ba',
+    codeCommune: '12345',
+    client: {
+      nom: 'Mes Adresses',
+      id: 'mes-adresses',
+      _id: '63f5eb7db804021c67e4e4dd',
+      mandataire: 'ANCT'
+    },
+    publishedAt: '2023-05-02T09:24:54.445Z'
+  },
+  {
+    _id: '6450d6e66ba2e9f7769df7bb',
+    codeCommune: '12346',
+    client: {
+      nom: 'Mes Adresses',
+      id: 'mes-adresses',
+      _id: '63f5eb7db804021c67e4e4dd',
+      mandataire: 'ANCT'
+    },
+    publishedAt: '2023-05-02T09:24:54.445Z'
+  },
+  {
+    _id: '6450d6e66ba2e9f7769df7bc',
+    codeCommune: '12347',
+    client: {
+      nom: 'Mes Adresses',
+      id: 'mes-adresses',
+      _id: '63f5eb7db804021c67e4e4dd',
+      mandataire: 'ANCT'
+    },
+    publishedAt: '2023-05-02T09:24:54.445Z'
+  }
+]
+
+export const bddCommuneMock = [
+  {
+    codeCommune: '12345',
+    idRevision: '6450d6e66ba2e9f7769df7ba',
+  },
+  {
+    codeCommune: '12346',
+    idRevision: '6450d6e66ba2e9f7769df7bd',
+  },
+  {
+    codeCommune: '12347',
+    idRevision: null,
+  }
+]

--- a/lib/compose/bal-garbage-collector/index.js
+++ b/lib/compose/bal-garbage-collector/index.js
@@ -1,0 +1,22 @@
+import bluebird from 'bluebird'
+import composeCommune from '../index.cjs'
+import {getCurrentRevisons} from '../../util/api-depot.cjs'
+import {getCommuneRevisionID} from './models.js'
+
+const CONCURRENCY = 5
+
+export const balGarbageCollector = async () => {
+  const [revisionBAL, revisionBAN] = await Promise.all([
+    getCurrentRevisons(),
+    getCommuneRevisionID()
+  ])
+
+  const idRevisionBAL = revisionBAL.map(({_id, codeCommune}) => [codeCommune, _id])
+  const idRevisionBAN = Object.fromEntries(revisionBAN.map(({idRevision, codeCommune}) => [codeCommune, idRevision]))
+
+  const codesCommunes = idRevisionBAL.filter(([codeCommune, idRevision]) => idRevisionBAN[codeCommune] !== idRevision)
+
+  // Promesses avec concurrence
+  const communeComposed = await bluebird.map(codesCommunes, ([codeCommune]) => composeCommune(codeCommune), {concurrency: CONCURRENCY})
+  return communeComposed
+}

--- a/lib/compose/bal-garbage-collector/index.spec.js
+++ b/lib/compose/bal-garbage-collector/index.spec.js
@@ -1,0 +1,15 @@
+import {jest} from '@jest/globals'
+import {bddCommuneMock} from './__mocks__/revision-data-mock.js'
+
+jest.unstable_mockModule('../../util/api-depot.cjs', async () => import('./__mocks__/api-depot-mock.js'))
+jest.unstable_mockModule('./models.js', async () => import('./__mocks__/models-mock.js'))
+jest.unstable_mockModule('../index.cjs', async () => import('./__mocks__/compose-mock.js'))
+
+const {balGarbageCollector} = await import('./index.js')
+
+describe('balGarbageCollector', () => {
+  it('RevisionIDs from BAL and BAN are different', async () => {
+    const communeGarbageCollector = await balGarbageCollector()
+    expect(communeGarbageCollector).toEqual([bddCommuneMock[1].codeCommune, bddCommuneMock[2].codeCommune])
+  })
+})

--- a/lib/compose/bal-garbage-collector/models.js
+++ b/lib/compose/bal-garbage-collector/models.js
@@ -1,0 +1,7 @@
+import mongo from '../../util/mongo.cjs'
+
+async function getCommuneRevisionID() {
+  return mongo.db.collection('communes').find({}, {projection: {codeCommune: true, idRevision: true}}).toArray()
+}
+
+module.exports = {getCommuneRevisionID}

--- a/lib/util/api-depot.cjs
+++ b/lib/util/api-depot.cjs
@@ -19,4 +19,8 @@ async function getRevisionFile(revisionId) {
   return got(`${API_DEPOT_URL}/revisions/${revisionId}/files/bal/download`).buffer()
 }
 
-module.exports = {getCurrentRevision, getRevisionFile}
+async function getCurrentRevisons() {
+  return got(`${API_DEPOT_URL}/current-revisions`).json()
+}
+
+module.exports = {getCurrentRevision, getRevisionFile, getCurrentRevisons}

--- a/worker.js
+++ b/worker.js
@@ -9,9 +9,15 @@ import mongo from './lib/util/mongo.cjs'
 import queue from './lib/util/queue.cjs'
 import composeCommune from './lib/jobs/compose-commune.cjs'
 import computeBanStats from './lib/jobs/compute-ban-stats.cjs'
+import balGarbageCollector from './lib/compose/bal-garbage-collector/index.js'
 
 async function main() {
   await mongo.connect()
+
+  if (process.env.NODE_ENV === 'production') {
+    // Garbage collector
+    await balGarbageCollector()
+  }
 
   // Legacy
   queue('compose-commune').process(2, composeCommune)


### PR DESCRIPTION
#129
Actuellement, lors de déploiement pour mise en production de nouveau code, l'API BAN peut ne pas répondre pendant quelques minutes. L'API de dépôt appelle l'API BAN lors de la mise à jour d'une BAL. En cas d'indisponibilité de l'API BAN elle ne traite pas l'erreur et ne re-tente pas la publication.
Cette PR permet lors du lancement de l'API BAN de comparer l'id de révision des BAL de l'API dépôt avec l'id de révision qui est dans la BAN et de lancer une récupération de la BAL si les id de révision ne correspondent pas.