### PR TITLE
Added common toponym ID delta report api route + fix

### DIFF
--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -160,11 +160,14 @@ export const checkAddressesRequest = async (addresses, actionType) => {
 export const getDeltaReport = async (addressIDs, codeCommune) => {
   const allAddressIDsFromCommune = await getAllAddressIDsFromCommune(codeCommune)
 
-  const idsToCreate = addressIDs.filter(id => !allAddressIDsFromCommune.includes(id))
+  let idsToCreate = addressIDs.filter(id => !allAddressIDsFromCommune.includes(id))
   const idsToUpdate = addressIDs.filter(id => allAddressIDsFromCommune.includes(id))
   const idsToDelete = allAddressIDsFromCommune.filter(id => !addressIDs.includes(id))
 
   const idsUnauthorized = await getAllAddressIDsOutsideCommune(idsToCreate, codeCommune)
+  if (idsUnauthorized.length > 0) {
+    idsToCreate = idsToCreate.filter(id => !idsUnauthorized.includes(id))
+  }
 
   return {idsToCreate, idsToUpdate, idsToDelete, idsUnauthorized}
 }

--- a/lib/api/common-toponym/__mocks__/common-toponym-models.js
+++ b/lib/api/common-toponym/__mocks__/common-toponym-models.js
@@ -3,3 +3,11 @@ import {bddCommonToponymMock} from './common-toponym-data-mock.js'
 export async function getCommonToponyms(commonToponymIDs) {
   return bddCommonToponymMock.filter(({id}) => commonToponymIDs.includes(id))
 }
+
+export async function getAllCommonToponymIDsFromCommune(codeCommune) {
+  return bddCommonToponymMock.filter(({codeCommune: codeCommuneCommonToponym}) => codeCommuneCommonToponym === codeCommune).map(({id}) => id)
+}
+
+export async function getAllCommonToponymIDsOutsideCommune(commonToponymIDs, codeCommune) {
+  return bddCommonToponymMock.filter(({id, codeCommune: codeCommuneCommonToponym}) => commonToponymIDs.includes(id) && codeCommuneCommonToponym !== codeCommune).map(({id}) => id)
+}

--- a/lib/api/common-toponym/models.js
+++ b/lib/api/common-toponym/models.js
@@ -10,6 +10,14 @@ export async function getCommonToponyms(commonToponymIDs) {
   return mongo.db.collection(COLLECTION_COMMON_TOPONYM).find({id: {$in: commonToponymIDs}}).toArray()
 }
 
+export async function getAllCommonToponymIDsFromCommune(codeCommune) {
+  return mongo.db.collection(COLLECTION_COMMON_TOPONYM).find({codeCommune}).project({id: 1, _id: 0}).map(commonToponym => commonToponym.id).toArray()
+}
+
+export async function getAllCommonToponymIDsOutsideCommune(commontToponymIDs, codeCommune) {
+  return mongo.db.collection(COLLECTION_COMMON_TOPONYM).find({id: {$in: commontToponymIDs}, codeCommune: {$ne: codeCommune}}).project({id: 1, _id: 0}).map(commonToponym => commonToponym.id).toArray()
+}
+
 export async function setCommonToponyms(commonToponyms) {
   return mongo.db.collection(COLLECTION_COMMON_TOPONYM).insertMany(commonToponyms)
 }

--- a/lib/api/common-toponym/routes.js
+++ b/lib/api/common-toponym/routes.js
@@ -4,6 +4,7 @@ import express from 'express'
 import queue from '../../util/queue.cjs'
 import auth from '../../middleware/auth.js'
 import {getCommonToponym, deleteCommonToponym} from './models.js'
+import {getDeltaReport} from './utils.js'
 
 const apiQueue = queue('api')
 
@@ -124,6 +125,34 @@ app.delete('/:commonToponymID', async (req, res) => {
       date: new Date(),
       status: 'error',
       message,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
+app.post('/delta-report', auth, async (req, res) => {
+  let response
+  try {
+    const {commonToponymIDs, codeCommune} = req.body
+
+    if (!commonToponymIDs || !codeCommune) {
+      res.status(404).send('Wrong request format')
+      return
+    }
+
+    const deltaReport = await getDeltaReport(commonToponymIDs, codeCommune)
+    response = {
+      date: new Date(),
+      status: 'success',
+      response: deltaReport,
+    }
+  } catch (error) {
+    response = {
+      date: new Date(),
+      status: 'error',
+      message: error,
       response: {},
     }
   }

--- a/lib/api/common-toponym/utils.js
+++ b/lib/api/common-toponym/utils.js
@@ -1,4 +1,4 @@
-import {getCommonToponyms} from './models.js'
+import {getCommonToponyms, getAllCommonToponymIDsFromCommune, getAllCommonToponymIDsOutsideCommune} from './models.js'
 import {banCommonToponymSchema} from './schema.js'
 
 const report = (isValid, message, data) => ({
@@ -80,3 +80,14 @@ export const checkCommonToponymsRequest = async (commonToponyms, type) => {
   return report(true)
 }
 
+export const getDeltaReport = async (commonToponymIDs, codeCommune) => {
+  const allCommonToponymIDsFromCommune = await getAllCommonToponymIDsFromCommune(codeCommune)
+
+  const idsToCreate = commonToponymIDs.filter(id => !allCommonToponymIDsFromCommune.includes(id))
+  const idsToUpdate = commonToponymIDs.filter(id => allCommonToponymIDsFromCommune.includes(id))
+  const idsToDelete = allCommonToponymIDsFromCommune.filter(id => !commonToponymIDs.includes(id))
+
+  const idsUnauthorized = await getAllCommonToponymIDsOutsideCommune(idsToCreate, codeCommune)
+
+  return {idsToCreate, idsToUpdate, idsToDelete, idsUnauthorized}
+}

--- a/lib/api/common-toponym/utils.js
+++ b/lib/api/common-toponym/utils.js
@@ -83,11 +83,14 @@ export const checkCommonToponymsRequest = async (commonToponyms, type) => {
 export const getDeltaReport = async (commonToponymIDs, codeCommune) => {
   const allCommonToponymIDsFromCommune = await getAllCommonToponymIDsFromCommune(codeCommune)
 
-  const idsToCreate = commonToponymIDs.filter(id => !allCommonToponymIDsFromCommune.includes(id))
+  let idsToCreate = commonToponymIDs.filter(id => !allCommonToponymIDsFromCommune.includes(id))
   const idsToUpdate = commonToponymIDs.filter(id => allCommonToponymIDsFromCommune.includes(id))
   const idsToDelete = allCommonToponymIDsFromCommune.filter(id => !commonToponymIDs.includes(id))
 
   const idsUnauthorized = await getAllCommonToponymIDsOutsideCommune(idsToCreate, codeCommune)
+  if (idsUnauthorized.length > 0) {
+    idsToCreate = idsToCreate.filter(id => !idsUnauthorized.includes(id))
+  }
 
   return {idsToCreate, idsToUpdate, idsToDelete, idsUnauthorized}
 }


### PR DESCRIPTION
Context : 
When a BAL is going to be published with BAN-IDs, we need to be able to get the information of which common toponym have to be created, which have to be updated and which have to be deleted. 

Enhancements : 
We have created a new api route that returns a delta report. Here are the information about this route : 
- endpoint : /common-toponym/delta-report
- body : `{commonToponymIDs:[...], codeCommune:'...'}` (commonToponymIDs array and codeCommune string are mandatory)
- response : `{idsToCreate:[...], idsToUpdate:[...], idsToDelete:[...], idsUnauthorized}`

How to test : 

In your local environnement, insert two news addresses with the POST /common-toponym route. Here is an example of the body : 

```
[
    {
        "id": "00000000-0000-4fff-9fff-00000000002a",
        "codeCommune": "12345",
        "label": [
            {
                "isoCode": "fr",
                "value": "Rue de la baleine"
            }
        ],
        "type": {
            "value": "voie"
        },
        "geometry": {
            "type": "Point",
            "coordinates": [
                1.2345,
                2.3456
            ]
        },
        "dateMAJ": "2023-04-24"
    },
    {
        "id": "00000000-0000-4fff-9fff-00000000002b",
        "codeCommune": "12345",
        "label": [
            {
                "isoCode": "fr",
                "value": "Rue de la loutre"
            }
        ],
        "type": {
            "value": "voie"
        },
        "geometry": {
            "type": "Point",
            "coordinates": [
                1.2345,
                2.3456
            ]
        },
        "dateMAJ": "2023-04-24"
    },
 {
        "id": "00000000-0000-4fff-9fff-00000000002e",
        "codeCommune": "12346",
        "label": [
            {
                "isoCode": "fr",
                "value": "Rue des nénuphar"
            }
        ],
        "type": {
            "value": "voie"
        },
        "geometry": {
            "type": "Point",
            "coordinates": [
                1.2345,
                2.3456
            ]
        },
        "dateMAJ": "2023-04-24"
    }
]
```

Then, get the delta report by using the new route POST /common-toponym/delta-report. Here is an example of the body : 

```
{
    "codeCommune": "12345",
    "commonToponymIDs": [
        "00000000-0000-4fff-9fff-00000000002a",
        "00000000-0000-4fff-9fff-00000000002d",
        "00000000-0000-4fff-9fff-00000000002e"
    ]
}
```

Response must be : 

```
{
    "date": "2023-05-02T09:33:58.120Z",
    "status": "success",
    "response": {
        "idsToCreate": [
            "00000000-0000-4fff-9fff-00000000002d"
        ],
        "idsToUpdate": [
            "00000000-0000-4fff-9fff-00000000002a"
        ],
        "idsToDelete": [
            "00000000-0000-4fff-9fff-00000000002b"
        ],
        "idsUnauthorized": [
            "00000000-0000-4fff-9fff-00000000002e"
        ]
    }
}
```

Also, this PR is fixing the fact that unauthorized IDs were not filtered out from ids to create.