### PR TITLE
Added banID field to 'voie', 'numero' and 'commune' schemas + csv-bal export

### DIFF
--- a/lib/compose/index.cjs
+++ b/lib/compose/index.cjs
@@ -11,6 +11,7 @@ const source = require('../models/source.cjs')
 const {createPseudoCodeVoieGenerator} = require('../pseudo-codes-voies.cjs')
 const {getCurrentRevision} = require('../util/api-depot.cjs')
 
+const {digestIDsFromBalUIDs} = require('../util/digest-ids-from-bal-uids.cjs')
 const MS = require('./strategies/multi-sources/index.cjs')
 const BAL = require('./strategies/bal/index.cjs')
 
@@ -113,7 +114,11 @@ async function composeCommune(codeCommune) {
   const nbNumeros = voies.reduce((acc, voie) => acc + voie.nbNumeros, 0)
   const nbNumerosCertifies = numeros.filter(n => n.certifie).length
 
+  const {uidAdresse} = balData.adresses[0]
+  const {districtID} = digestIDsFromBalUIDs(uidAdresse)
+
   const communeRecord = {
+    banId: districtID,
     nomCommune: communeCOG.nom,
     population: communeCOG.population,
     departement: pick(getDepartement(communeCOG.departement), 'nom', 'code'),

--- a/lib/compose/strategies/bal/lieux-dits.cjs
+++ b/lib/compose/strategies/bal/lieux-dits.cjs
@@ -1,14 +1,21 @@
 const {uniqBy} = require('lodash')
 const {beautifyUppercased} = require('../../../util/string.cjs')
+const {digestIDsFromBalUIDs} = require('../../../util/digest-ids-from-bal-uids.cjs')
 const generateIds = require('../../processors/generate-ids.cjs')
 
 async function buildLieuxDits(balData, {codeCommune, pseudoCodeVoieGenerator, existingVoiesIds}) {
   generateIds(balData.lieuxDits, {codeCommune, pseudoCodeVoieGenerator})
   return uniqBy(balData.lieuxDits, 'idVoie').filter(ld => !existingVoiesIds.has(ld.idVoie))
-    .map(lieuDit => ({
-      ...lieuDit,
-      nomVoie: beautifyUppercased(lieuDit.nomVoie)
-    }))
+    .map(lieuDit => {
+      const {uidAdresse} = lieuDit
+      const {mainTopoID, districtID} = digestIDsFromBalUIDs(uidAdresse)
+      return {
+        ...lieuDit,
+        banId: mainTopoID,
+        banIdDistrict: districtID,
+        nomVoie: beautifyUppercased(lieuDit.nomVoie)
+      }
+    })
 }
 
 module.exports = {buildLieuxDits}

--- a/lib/compose/strategies/bal/numero.cjs
+++ b/lib/compose/strategies/bal/numero.cjs
@@ -3,6 +3,7 @@ const {feature} = require('@turf/turf')
 const {computeBufferedBbox, derivePositionProps} = require('../../../util/geo.cjs')
 const {getCodePostalRecord} = require('../../../util/codes-postaux.cjs')
 const {beautifyUppercased} = require('../../../util/string.cjs')
+const {digestIDsFromBalUIDs} = require('../../../util/digest-ids-from-bal-uids.cjs')
 
 function normalizeSuffixe(suffixe) {
   if (!suffixe) {
@@ -40,7 +41,8 @@ function getBestPosition(positions) {
 }
 
 function buildNumero(numeroAdresses, {idVoieFantoir, codeCommune, forceCertification}) {
-  const {numero, lieuDitComplementNom, lieuDitComplementNomAlt, parcelles, certificationCommune, codeAncienneCommune, nomAncienneCommune, dateMAJ} = numeroAdresses[0]
+  const {uidAdresse, numero, lieuDitComplementNom, lieuDitComplementNomAlt, parcelles, certificationCommune, codeAncienneCommune, nomAncienneCommune, dateMAJ} = numeroAdresses[0]
+  const {addressID, mainTopoID, secondaryTopoIDs, districtID} = digestIDsFromBalUIDs(uidAdresse)
   const suffixe = normalizeSuffixe(numeroAdresses[0].suffixe)
 
   const positions = numeroAdresses
@@ -58,6 +60,10 @@ function buildNumero(numeroAdresses, {idVoieFantoir, codeCommune, forceCertifica
   )
 
   return {
+    banId: addressID,
+    banIdMainCommonToponym: mainTopoID,
+    banIdSecondaryCommonToponyms: secondaryTopoIDs,
+    banIdDistrict: districtID,
     numero,
     suffixe,
     lieuDitComplementNom: lieuDitComplementNom ? beautifyUppercased(lieuDitComplementNom) : null,

--- a/lib/compose/strategies/bal/voies.cjs
+++ b/lib/compose/strategies/bal/voies.cjs
@@ -4,6 +4,7 @@ const {feature} = require('@turf/turf')
 const {computeBufferedBbox, getCenterFromPoints, derivePositionProps} = require('../../../util/geo.cjs')
 const {getCodePostalRecord} = require('../../../util/codes-postaux.cjs')
 const {beautifyUppercased} = require('../../../util/string.cjs')
+const {digestIDsFromBalUIDs} = require('../../../util/digest-ids-from-bal-uids.cjs')
 
 const generateIds = require('../../processors/generate-ids.cjs')
 const computeGroups = require('../../processors/compute-groups.cjs')
@@ -40,6 +41,8 @@ function buildVoies(balData, {codeCommune, pseudoCodeVoieGenerator, forceCertifi
   const voies = chain(adressesWithGroups)
     .groupBy('groupId')
     .map(adresses => {
+      const {uidAdresse} = first(adresses)
+      const {mainTopoID, districtID} = digestIDsFromBalUIDs(uidAdresse)
       /* Noms voie */
       const {nomVoie, nomVoieAlt, idVoie: idVoieFantoir} = buildNomVoie(adresses)
 
@@ -57,6 +60,8 @@ function buildVoies(balData, {codeCommune, pseudoCodeVoieGenerator, forceCertifi
       const {lon, lat, x, y, tiles} = derivePositionProps(centroid, 10, 14)
 
       return {
+        banId: mainTopoID,
+        banIdDistrict: districtID,
         groupId,
         idVoie: idVoieFantoir,
         idVoieFantoir,

--- a/lib/formatters/csv-bal.cjs
+++ b/lib/formatters/csv-bal.cjs
@@ -1,6 +1,7 @@
 /* eslint camelcase: off */
 const {groupBy} = require('lodash')
 const {harmlessProj} = require('../util/geo.cjs')
+const {idsIdentifier} = require('../util/digest-ids-from-bal-uids.cjs')
 
 const SOURCES_MAPPING = {
   bal: 'commune',
@@ -30,9 +31,27 @@ function extractHeaders(csvRows) {
   return [...headers]
 }
 
+function buildBalUIDAdresse(numero) {
+  const {banId, banIdMainCommonToponym, banIdSecondaryCommonToponyms, banIdDistrict} = numero
+  const banIDsFromNumero = {
+    addressID: banId,
+    mainTopoID: banIdMainCommonToponym,
+    secondaryTopoIDs: banIdSecondaryCommonToponyms?.join('|'),
+    districtID: banIdDistrict
+  }
+  return idsIdentifier.reduce((acc, {key, prefix}) => {
+    if (banIDsFromNumero[key]) {
+      return `${acc} ${prefix}${banIDsFromNumero[key]}`
+    }
+
+    return acc
+  }, '')
+}
+
 function buildRow(voie, numero, position, includesAlt = false) {
+  const uid_adresse = buildBalUIDAdresse(numero)
   const row = {
-    uid_adresse: '',
+    uid_adresse,
     cle_interop: numero.cleInterop,
     commune_insee: voie.codeCommune,
     commune_nom: voie.nomCommune,

--- a/lib/util/digest-ids-from-bal-uids.cjs
+++ b/lib/util/digest-ids-from-bal-uids.cjs
@@ -1,0 +1,58 @@
+const regExpUUIDv4 = /[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}/i
+
+const idsIdentifier = [
+  {
+    key: 'addressID',
+    prefix: '@a:',
+    regExp: regExpUUIDv4,
+  },
+  {
+    key: 'mainTopoID',
+    prefix: '@v:',
+    regExp: regExpUUIDv4,
+  },
+  {
+    key: 'secondaryTopoIDs',
+    prefix: '@t:',
+    regExp: `${regExpUUIDv4.source}`,
+    batch: true,
+  },
+  {
+    key: 'districtID',
+    prefix: '@c:',
+    regExp: regExpUUIDv4,
+  }
+]
+
+const digestIDsFromBalUIDs = ids => {
+  const regExpIds = new RegExp(
+    idsIdentifier.reduce(
+      (acc, {key, prefix, regExp, batch = false}) => {
+        const strRegExp = typeof regExp === 'string' ? regExp : regExp.source
+        const keyRegExp = batch ? `(\\|?${strRegExp})*` : strRegExp
+        return `${acc ? `${acc}|` : ''}(${prefix}(?<${key}>${`${keyRegExp}`}))`
+      },
+      ''
+    ),
+    'igm'
+  )
+
+  return Object.fromEntries(
+    ids
+      ? [...ids.matchAll(regExpIds)].flatMap(({groups}) =>
+        Object.entries(groups)
+          .filter(([, value]) => value)
+          .map(([key, value]) => {
+            switch (key) {
+              case 'secondaryTopoIDs':
+                return [key, (value).split('|')]
+              default:
+                return [key, value]
+            }
+          })
+      )
+      : []
+  )
+}
+
+module.exports = {idsIdentifier, digestIDsFromBalUIDs}


### PR DESCRIPTION
I. Context : 

Currently, we are not importing data from the BAL field "uid_Adresse". We would like to be able to import BAN-IDs from the BAL using this specification : https://github.com/BaseAdresseNationale/ban-plateforme/issues/184

II. Enhancement

This PR aims to add the BAN-IDs in the data base as following : 

"numero" collection : 
- banId : ID after "`@a:`" suffix
- banIdMainCommonToponym : ID after "`@v:`" suffix
- banIdSecondaryCommonToponyms: not supported for now
- banIdDistrict : ID after "`@c:`" suffix

"voie" collection : 
- banId : ID after "`@v:`" suffix
- banIdDistrict : ID after "`@c:`" suffix

"commune" collection : 
- banId : ID after "`@c:`" suffix