### PR TITLE
fix job ids

### DIFF
--- a/lib/models/commune.cjs
+++ b/lib/models/commune.cjs
@@ -17,7 +17,7 @@ async function askComposition(codeCommune, options = {}) {
     {$set: {compositionAskedAt: now, compositionOptions: options}},
     {upsert: true}
   )
-  await compositionQueue.add({codeCommune: communeActuelle.code, compositionAskedAt: now}, {jobId: `composeCommuneJobId-${communeActuelle.code}`, removeOnComplete: true})
+  await compositionQueue.add({codeCommune: communeActuelle.code, compositionAskedAt: now}, {removeOnComplete: true})
 }
 
 async function askCompositionAll() {

--- a/worker.js
+++ b/worker.js
@@ -23,12 +23,12 @@ async function main() {
   // Legacy
   queue('compose-commune').process(2, composeCommune)
   queue('compute-ban-stats').process(1, computeBanStats)
-  queue('compute-ban-stats').add({}, {repeat: {every: ms('15m')}, removeOnComplete: true})
+  queue('compute-ban-stats').add({}, {jobId: 'computeBanStatsJobId', repeat: {every: ms('15m')}, removeOnComplete: true})
 
   // BanID
   queue('api').process(1, apiConsumer)
   queue('clean-job-status').process(1, cleanJobStatusConsumer)
-  queue('clean-job-status').add({}, {repeat: {every: ms('1d')}, removeOnComplete: true})
+  queue('clean-job-status').add({}, {jobId: 'cleanJobStatusJobId', repeat: {every: ms('1d')}, removeOnComplete: true})
 }
 
 main().catch(error => {


### PR DESCRIPTION
This PR is to solved the issue raised by @IGNFBourcier in this other PR : https://github.com/BaseAdresseNationale/ban-plateforme/pull/159

Context : 
We have added a job id to the job that is sent to the queue each time a composition is asked (function askComposition() from the file lib/models/comune.cjs). The job id has been added so that there is only one job with this ID in the queue.
The issue is that, before the job is sent, the data base is updated with : 

```
await mongo.db.collection('communes').findOneAndUpdate(
    {codeCommune: communeActuelle.code},
    {$set: {compositionAskedAt: now, compositionOptions: options}},
    {upsert: true} 
)
```

And when the job is taken by a consumer, the first thing that is done is to check if the date in the data base and in the job data is the same : 

```
if (!communeEntry.compositionAskedAt || !isEqual(communeEntry.compositionAskedAt, parseISO(compositionAskedAt))) {
    return
}
```

By adding a jobId, we prevent jobs to enter the queue, BUT data is modified in the data base. As a consequence, adding a jobId will lead to ignored compose. 

Fix : 
- We have deleted the jobId when a compose is asked.

Enhancements : 
- We have added a jobID to the compute-ban-stats and clean-job-status repeated jobs so that only one job is existing in the queue even if worker is a multi-instance process.