### PR TITLE
District API routes (GET, POST, PUT, DELETE)

### DIFF
--- a/lib/api/common-toponym/utils.spec.js
+++ b/lib/api/common-toponym/utils.spec.js
@@ -3,7 +3,7 @@ import {object, string, bool, array} from 'yup'
 import {commonToponymMock, bddCommonToponymMock} from './__mocks__/common-toponym-data-mock.js'
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/common-toponym-models.js'))
-const {checkCommonToponymsRequest} = await import('./utils.js')
+const {checkCommonToponymsRequest, checkCommonToponymsIDsRequest} = await import('./utils.js')
 
 const commonToponymsValidationSchema = object({
   isValid: bool().required(),
@@ -13,8 +13,45 @@ const commonToponymsValidationSchema = object({
   }),
 })
 
+describe('checkCommonToponymsIDsRequest', () => {
+  it('Unavailable IDs on insert', async () => {
+    const commonToponymsValidation = await checkCommonToponymsIDsRequest(bddCommonToponymMock.map(({id}) => id), 'insert')
+    const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(commonToponymsValidation?.isValid).toBe(false)
+    expect(commonToponymsValidation?.report?.data).toEqual(bddCommonToponymMock.map(({id}) => id))
+  })
+
+  it('Shared IDs on delete', async () => {
+    const sharedID = bddCommonToponymMock[0].id
+    const commonToponymsValidation = await checkCommonToponymsIDsRequest(bddCommonToponymMock.map(({id}, i) => i < 2 ? sharedID : id), 'delete')
+    const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(commonToponymsValidation?.isValid).toBe(false)
+    expect(commonToponymsValidation?.report?.data).toEqual([sharedID])
+  })
+
+  it('All unkown IDs', async () => {
+    const commonToponymsValidation = await checkCommonToponymsIDsRequest(commonToponymMock.map(({id}) => id), 'delete')
+    const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(commonToponymsValidation?.isValid).toBe(false)
+    expect(commonToponymsValidation?.report?.data).toEqual(commonToponymMock.map(({id}) => id))
+    commonToponymMock.forEach(({id}) => expect(commonToponymsValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Some unkown IDs', async () => {
+    const commonToponymsValidation = await checkCommonToponymsIDsRequest([...commonToponymMock, ...bddCommonToponymMock].map(({id}) => id), 'delete')
+    const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(commonToponymsValidation?.isValid).toBe(false)
+    expect(commonToponymsValidation?.report?.data).toEqual(commonToponymMock.map(({id}) => id))
+    commonToponymMock.forEach(({id}) => expect(commonToponymsValidation?.report.data.includes(id)).toBe(true))
+  })
+})
+
 describe('checkCommonToponymsRequest', () => {
-  it('Shared  IDs', async () => {
+  it('Shared IDs', async () => {
     const sharedID = '00000000-0000-4fff-9fff-aaaaaaaaaaaa'
     const commonToponymsValidation = await checkCommonToponymsRequest(commonToponymMock.map(commonToponym => ({...commonToponym, id: sharedID})), 'insert')
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})

--- a/lib/api/consumers/api-consumer.js
+++ b/lib/api/consumers/api-consumer.js
@@ -3,6 +3,8 @@ import {setAddresses, updateAddresses, deleteAddresses} from '../address/models.
 import {checkAddressesRequest, checkAddressesIDsRequest} from '../address/utils.js'
 import {setCommonToponyms, updateCommonToponyms, deleteCommonToponyms} from '../common-toponym/models.js'
 import {checkCommonToponymsRequest, checkCommonToponymsIDsRequest} from '../common-toponym/utils.js'
+import {setDistricts, updateDistricts, deleteDistricts} from '../district/models.js'
+import {checkDistrictsRequest, checkDistrictsIDsRequest} from '../district/utils.js'
 import {dataValidationReportFrom} from '../helper.js'
 
 export default async function apiConsumers({data: {dataType, jobType, data, statusID}}, done) {
@@ -13,6 +15,9 @@ export default async function apiConsumers({data: {dataType, jobType, data, stat
         break
       case 'commonToponym':
         await commonToponymConsumer(jobType, data, statusID)
+        break
+      case 'district':
+        await districtConsumer(jobType, data, statusID)
         break
       default:
         console.warn(`Consumer Warn: Unknown data type : '${dataType}'`)
@@ -121,6 +126,54 @@ const commonToponymConsumer = async (jobType, payload, statusID) => {
       jobType,
       count: commonToponymsCount,
       message: 'common toponyms are not valid',
+      report: requestDataValidationReport.report,
+    })
+  }
+}
+
+const districtConsumer = async (jobType, payload, statusID) => {
+  const checkRequestData = async (payload, jobType) => {
+    switch (jobType) {
+      case 'insert':
+      case 'update':
+        return checkDistrictsRequest(payload, jobType)
+      case 'delete':
+        return checkDistrictsIDsRequest(payload, jobType)
+      default:
+        return dataValidationReportFrom(false, 'Unknown action type', {actionType: jobType, payload})
+    }
+  }
+
+  const requestDataValidationReport = await checkRequestData(payload, jobType)
+  const districtsCount = payload.length
+  if (requestDataValidationReport.isValid) {
+    switch (jobType) {
+      case 'insert':
+        await setDistricts(payload)
+        break
+      case 'update':
+        await updateDistricts(payload)
+        break
+      case 'delete':
+        await deleteDistricts(payload)
+        break
+      default:
+        console.warn(`District Consumer Warn: Unknown job type : '${jobType}'`)
+    }
+
+    await setJobStatus(statusID, {
+      status: 'success',
+      dataType: 'district',
+      jobType,
+      count: districtsCount,
+    })
+  } else {
+    await setJobStatus(statusID, {
+      status: 'error',
+      dataType: 'district',
+      jobType,
+      count: districtsCount,
+      message: 'districts are not valid',
       report: requestDataValidationReport.report,
     })
   }

--- a/lib/api/district/__mocks__/district-data-mock.js
+++ b/lib/api/district/__mocks__/district-data-mock.js
@@ -1,0 +1,49 @@
+export const districtMock = [
+  {
+    id: '00000000-0000-4fff-9fff-00000000000a',
+    label: [{
+      isoCode: 'fr',
+      value: 'Commune A'
+    }]
+  },
+  {
+    id: '00000000-0000-4fff-9fff-00000000000b',
+    label: [{
+      isoCode: 'fr',
+      value: 'Commune B'
+    }]
+  },
+]
+
+export const bddDistrictMock = [
+  {
+    _id: {
+      $oid: '000000000000000000000001'
+    },
+    id: '00000000-0000-4fff-9fff-000000000000',
+    label: [{
+      isoCode: 'fr',
+      value: 'Commune C'
+    }]
+  },
+  {
+    _id: {
+      $oid: '000000000000000000000002'
+    },
+    id: '00000000-0000-4fff-9fff-000000000001',
+    label: [{
+      isoCode: 'fr',
+      value: 'Commune D'
+    }]
+  },
+  {
+    _id: {
+      $oid: '000000000000000000000003'
+    },
+    id: '00000000-0000-4fff-9fff-000000000002',
+    label: [{
+      isoCode: 'fr',
+      value: 'Commune E'
+    }]
+  }
+]

--- a/lib/api/district/__mocks__/district-models.js
+++ b/lib/api/district/__mocks__/district-models.js
@@ -1,0 +1,5 @@
+import {bddDistrictMock} from './district-data-mock.js'
+
+export async function getDistricts(districtIDs) {
+  return bddDistrictMock.filter(({id}) => districtIDs.includes(id))
+}

--- a/lib/api/district/models.js
+++ b/lib/api/district/models.js
@@ -1,0 +1,36 @@
+import mongo from '../../util/mongo.cjs'
+
+const COLLECTION_DISTRICT = 'district_test'
+
+export async function getDistrict(disrtrictID) {
+  return mongo.db.collection(COLLECTION_DISTRICT).findOne({id: disrtrictID})
+}
+
+export async function getDistricts(disrtrictIDs) {
+  return mongo.db.collection(COLLECTION_DISTRICT).find({id: {$in: disrtrictIDs}}).toArray()
+}
+
+export async function setDistricts(disrtricts) {
+  return mongo.db.collection(COLLECTION_DISTRICT).insertMany(disrtricts)
+}
+
+export async function updateDistricts(disrtricts) {
+  const bulkOperations = disrtricts.map(disrtrict => {
+    const filter = {id: disrtrict.id}
+    return {
+      updateOne: {
+        filter,
+        update: {$set: disrtrict}
+      }
+    }
+  })
+  return mongo.db.collection(COLLECTION_DISTRICT).bulkWrite(bulkOperations)
+}
+
+export async function deleteDistrict(disrtrictID) {
+  return mongo.db.collection(COLLECTION_DISTRICT).deleteOne({id: disrtrictID})
+}
+
+export async function deleteDistricts(disrtrictIDs) {
+  return mongo.db.collection(COLLECTION_DISTRICT).deleteMany({id: {$in: disrtrictIDs}})
+}

--- a/lib/api/district/routes.js
+++ b/lib/api/district/routes.js
@@ -1,0 +1,162 @@
+import 'dotenv/config.js' // eslint-disable-line import/no-unassigned-import
+import {customAlphabet} from 'nanoid'
+import express from 'express'
+import queue from '../../util/queue.cjs'
+import auth from '../../middleware/auth.js'
+import {getDistrict, deleteDistrict} from './models.js'
+
+const apiQueue = queue('api')
+
+const BAN_API_URL
+  = process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr'
+
+const nanoid = customAlphabet('123456789ABCDEFGHJKMNPQRSTVWXYZ', 9)
+
+const app = new express.Router()
+app.use(express.json())
+
+app.get('/:districtID', async (req, res) => {
+  let response
+  try {
+    const {districtID} = req.params
+    const district = await getDistrict(districtID)
+
+    if (!district) {
+      res.status(404).send('Request ID unknown')
+      return
+    }
+
+    const {_id, ...districtBody} = district
+    response = {
+      date: new Date(),
+      status: 'success',
+      response: {...districtBody},
+    }
+  } catch (error) {
+    const {message} = error
+    response = {
+      date: new Date(),
+      status: 'error',
+      message,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
+app.post('/', auth, async (req, res) => {
+  let response
+  try {
+    const districts = req.body
+    const statusID = nanoid()
+
+    await apiQueue.add(
+      {dataType: 'district', jobType: 'insert', data: districts, statusID},
+      {jobId: statusID, removeOnComplete: true}
+    )
+    response = {
+      date: new Date(),
+      status: 'success',
+      message: `Check the status of your request : ${BAN_API_URL}/job-status/${statusID}`,
+      response: {statusID},
+    }
+  } catch (error) {
+    response = {
+      date: new Date(),
+      status: 'error',
+      message: error,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
+app.put('/', auth, async (req, res) => {
+  let response
+  try {
+    const districts = req.body
+    const statusID = nanoid()
+
+    await apiQueue.add(
+      {dataType: 'district', jobType: 'update', data: districts, statusID},
+      {jobId: statusID, removeOnComplete: true}
+    )
+    response = {
+      date: new Date(),
+      status: 'success',
+      message: `Check the status of your request : ${BAN_API_URL}/job-status/${statusID}`,
+      response: {statusID},
+    }
+  } catch (error) {
+    response = {
+      date: new Date(),
+      status: 'error',
+      message: error,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
+app.delete('/:districtID', auth, async (req, res) => {
+  let response
+  try {
+    const {districtID} = req.params
+    const district = await getDistrict(districtID)
+
+    if (!district) {
+      res.status(404).send('Request ID unknown')
+      return
+    }
+
+    await deleteDistrict(districtID)
+    response = {
+      date: new Date(),
+      status: 'success',
+      response: {},
+    }
+  } catch (error) {
+    const {message} = error
+    response = {
+      date: new Date(),
+      status: 'error',
+      message,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
+app.post('/delete', auth, async (req, res) => {
+  let response
+  try {
+    const districtIDs = req.body
+    const statusID = nanoid()
+
+    await apiQueue.add(
+      {dataType: 'district', jobType: 'delete', data: districtIDs, statusID},
+      {jobId: statusID, removeOnComplete: true}
+    )
+    response = {
+      date: new Date(),
+      status: 'success',
+      message: `Check the status of your request : ${BAN_API_URL}/job-status/${statusID}`,
+      response: {statusID},
+    }
+  } catch (error) {
+    response = {
+      date: new Date(),
+      status: 'error',
+      message: error,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
+export default app

--- a/lib/api/district/schema.js
+++ b/lib/api/district/schema.js
@@ -1,0 +1,13 @@
+import {object, string, array} from 'yup'
+
+export const banDistrictID = string().trim().uuid()
+
+const labelSchema = object({
+  isoCode: string().trim().required(),
+  value: string().trim().required(),
+})
+
+export const banDistrictSchema = object({
+  id: banDistrictID.required(),
+  label: array().of(labelSchema).required(),
+})

--- a/lib/api/district/utils.js
+++ b/lib/api/district/utils.js
@@ -1,0 +1,65 @@
+import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema} from '../helper.js'
+import {getDistricts} from './models.js'
+import {banDistrictSchema, banDistrictID} from './schema.js'
+
+const getExistingDistrictIDs = async districtIDs => {
+  const existingDistricts = await getDistricts(districtIDs)
+  return existingDistricts.map(ditrict => ditrict.id)
+}
+
+export const checkDistrictsIDsRequest = async (districtIDs, actionType, defaultReturn = true) => {
+  let report = checkDataFormat(
+    `The request require an Array of district IDs but receive ${typeof districtIDs}`,
+    'No district ID send to job',
+    districtIDs
+  ) || await checkIdsShema('Invalid IDs format', districtIDs, banDistrictID)
+
+  if (!report) {
+    switch (actionType) {
+      case 'insert':
+        report = (
+          checkIdsIsUniq('Shared IDs in request', districtIDs)
+          || await checkIdsIsVacant('Unavailable IDs', districtIDs, getExistingDistrictIDs)
+        )
+        break
+      case 'update':
+        report = (
+          checkIdsIsUniq('Shared IDs in request', districtIDs)
+          || await checkIdsIsAvailable('Some unknown IDs', districtIDs, getExistingDistrictIDs)
+        )
+        break
+      case 'delete':
+        report = (
+          checkIdsIsUniq('Shared IDs in request', districtIDs)
+          || await checkIdsIsAvailable('Some unknown IDs', districtIDs, getExistingDistrictIDs)
+        )
+        break
+      default:
+        report = dataValidationReportFrom(false, 'Unknown action type', {actionType, districtIDs})
+    }
+  }
+
+  return report || (defaultReturn && dataValidationReportFrom(true)) || null
+}
+
+export const checkDistrictsRequest = async (districts, actionType) => {
+  let report
+
+  switch (actionType) {
+    case 'insert':
+    case 'update':
+      report = checkDataFormat(
+        `The request require an Array of district but receive ${typeof districts}`,
+        'No district send to job',
+        districts
+      )
+        || await checkDistrictsIDsRequest(districts.map(district => district.id), actionType, false)
+        || await checkDataShema('Invalid format', districts, banDistrictSchema)
+        || dataValidationReportFrom(true)
+      break
+    default:
+      report = dataValidationReportFrom(false, 'Unknown action type', {actionType, districts})
+  }
+
+  return report
+}

--- a/lib/api/district/utils.spec.js
+++ b/lib/api/district/utils.spec.js
@@ -1,0 +1,102 @@
+import {jest} from '@jest/globals'
+import {object, string, bool, array} from 'yup'
+import {districtMock, bddDistrictMock} from './__mocks__/district-data-mock.js'
+
+jest.unstable_mockModule('./models.js', async () => import('./__mocks__/district-models.js'))
+const {checkDistrictsIDsRequest, checkDistrictsRequest} = await import('./utils.js')
+
+const districtsValidationSchema = object({
+  isValid: bool().required(),
+  report: object({
+    message: string(),
+    data: array().of(string().uuid()),
+  }),
+})
+
+describe('checkDistrictsIDsRequest', () => {
+  it('Unavailable IDs on insert', async () => {
+    const districtsValidation = await checkDistrictsIDsRequest(bddDistrictMock.map(({id}) => id), 'insert')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(false)
+    expect(districtsValidation?.report?.data).toEqual(bddDistrictMock.map(({id}) => id))
+  })
+
+  it('Shared IDs on delete', async () => {
+    const sharedID = bddDistrictMock[0].id
+    const districtsValidation = await checkDistrictsIDsRequest(bddDistrictMock.map(({id}, i) => i < 2 ? sharedID : id), 'delete')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(false)
+    expect(districtsValidation?.report?.data).toEqual([sharedID])
+  })
+
+  it('All unkown IDs', async () => {
+    const districtsValidation = await checkDistrictsIDsRequest(districtMock.map(({id}) => id), 'delete')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(false)
+    expect(districtsValidation?.report?.data).toEqual(districtMock.map(({id}) => id))
+    districtMock.forEach(({id}) => expect(districtsValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Some unkown IDs', async () => {
+    const districtsValidation = await checkDistrictsIDsRequest([...districtMock, ...bddDistrictMock].map(({id}) => id), 'delete')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(false)
+    expect(districtsValidation?.report?.data).toEqual(districtMock.map(({id}) => id))
+    districtMock.forEach(({id}) => expect(districtsValidation?.report.data.includes(id)).toBe(true))
+  })
+})
+
+describe('checkDistrictsRequest', () => {
+  it('Shared IDs', async () => {
+    const sharedID = '00000000-0000-4fff-9fff-aaaaaaaaaaaa'
+    const districtsValidation = await checkDistrictsRequest(districtMock.map(district => ({...district, id: sharedID})), 'insert')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(false)
+    expect(districtsValidation?.report?.data).toEqual([sharedID])
+  })
+
+  it('All unavailable IDs', async () => {
+    const districtsValidation = await checkDistrictsRequest(bddDistrictMock.map(({_id, ...district}) => district), 'insert')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(false)
+    expect(districtsValidation?.report?.data).toEqual(bddDistrictMock.map(({id}) => id))
+    bddDistrictMock.forEach(({id}) => expect(districtsValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Some unavailable IDs', async () => {
+    const districtsValidation = await checkDistrictsRequest([...districtMock, ...bddDistrictMock].map(({_id, ...district}) => district), 'insert')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(false)
+    expect(districtsValidation?.report?.data).toEqual(bddDistrictMock.map(({id}) => id))
+    bddDistrictMock.forEach(({id}) => expect(districtsValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Available districts and IDs on Insert', async () => {
+    const districtsValidation = await checkDistrictsRequest(districtMock, 'insert')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(true)
+  })
+
+  it('Unknown IDs on Update', async () => {
+    const districtsValidation = await checkDistrictsRequest(districtMock, 'update')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(false)
+    districtMock.forEach(({id}) => expect(districtsValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Available districts on Update', async () => {
+    const districtsValidation = await checkDistrictsRequest(bddDistrictMock.map(district => ({...district, label: [{isoCode: 'fr', value: 'commune F'}]})), 'update')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(true)
+  })
+})

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ import mongo from './lib/util/mongo.cjs'
 
 import addressRoutes from './lib/api/address/routes.js'
 import commonToponymRoutes from './lib/api/common-toponym/routes.js'
+import districtRoutes from './lib/api/district/routes.js'
 import statusRoutes from './lib/api/job-status/routes.js'
 
 import legacyRoutes from './lib/api/legacy-routes.cjs'
@@ -29,6 +30,7 @@ async function main() {
   app.use('/', legacyRoutes)
   app.use('/address', addressRoutes)
   app.use('/common-toponym', commonToponymRoutes)
+  app.use('/district', districtRoutes)
   app.use('/job-status', statusRoutes)
 
   const port = process.env.PORT || 5000


### PR DESCRIPTION
Context : 
To be able to manipulate district data in the ban data base, we need to add api routes to get, create, modify and delete districts.

Enhacements : 
New api routes : 
- GET /district/{districtID}
- POST /district & PUT /district

body exemple : 
```
[
    {
        "id": "00000000-0000-4fff-9fff-00000000000a",
        "label": [
            {
                "isoCode": "fr",
                "value": "commune A"
            }
        ]
    }
]
```

- DELETE /district/{districtID}
- POST /district/delete

body exemple : 

`["00000000-0000-4fff-9fff-00000000000a","00000000-0000-4fff-9fff-00000000000b"]`
