### PR TITLE
ajout option qui interdit la réattribution d'un idFantoir BAL

### DIFF
--- a/lib/compose/processors/recompute-codes-voies.cjs
+++ b/lib/compose/processors/recompute-codes-voies.cjs
@@ -5,11 +5,12 @@ const {slugify} = require('../../util/string.cjs')
 const fantoirPath = process.env.FANTOIR_PATH || 'data/fantoir.sqlite'
 
 // Cette méthode sert à attribuer un code FANTOIR aux adresses, lorsque c'est possible
-async function recomputeCodesVoies(adressesCommune) {
+async function recomputeCodesVoies(adressesCommune, fromBal) {
   if (adressesCommune.length === 0) {
     return
   }
 
+  const listIdVoie = new Set()
   const {codeCommune} = first(adressesCommune)
   const fantoirCommune = await createFantoirCommune(codeCommune, {fantoirPath})
 
@@ -29,8 +30,14 @@ async function recomputeCodesVoies(adressesCommune) {
       const fantoir = findVoie(adresse.nomVoie, adresse.codeAncienneCommune)
 
       if (fantoir) {
-        // Avant de renvoyer les adresses on remplit l'idVoie trouvé
+        // Avant d'attribuer le fantoir je vérifie que le couple libellé/fantoir n'apparait pas dans le set
         const idVoie = fantoir.successeur?.replace('-', '_') || fantoir.codeCommune + '_' + fantoir.codeFantoir
+        if (fromBal && listIdVoie.has(idVoie)) {
+          return {adresses}
+        }
+
+        listIdVoie.add(idVoie)
+
         for (const adresse of adresses) {
           adresse.idVoie = idVoie
         }

--- a/lib/compose/sources/bal.cjs
+++ b/lib/compose/sources/bal.cjs
@@ -39,7 +39,7 @@ async function prepareData(adressesCommune, {codeCommune}) {
   await filterOutOfCommune(context)
 
   await updateCommunes(context.adresses)
-  await recomputeCodesVoies(context.adresses)
+  await recomputeCodesVoies(context.adresses, true)
 
   const adresses = context.adresses
     // On ne conserve pas les numéros au dessus de 10000 (et notamment les lieux-dits 99999)


### PR DESCRIPTION
Permet de corriger sur les BAL des fusions non désirées.

Exemple de correction.

Les numéros 20, 24 et 80 auparavant attribués à la Route de la Chaze injustement sont maintenant bien sur la Rue des 2 Fontaines.


uid_adresse | cle_interop | commune_insee | commune_nom | commune_deleguee_insee | commune_deleguee_nom | voie_nom | lieudit_complement_nom | numero | suffixe | position | x | y | long | lat | cad_parcelles | source | date_der_maj | certification_commune
  | 48009_is5ni3_00020 | 48009 | Peyre en Aubrac | 48060 | Fau-de-Peyre | Rue des 2 Fontaines | SalÃ¨les | 20 |   | entrÃ©e | 716734.67 | 6406107.3 | 3.211442 | 44.7539 | 480090600A0203 | commune | 01/03/2023 | 1 |  
  | 48009_is5ni3_00024 | 48009 | Peyre en Aubrac | 48060 | Fau-de-Peyre | Rue des 2 Fontaines | SalÃ¨les | 24 |   | entrÃ©e | 716728.1 | 6406109.17 | 3.211359 | 44.753917 | 480090600A0202 | commune | 01/03/2023 | 1 |  
  | 48009_is5ni3_00080 | 48009 | Peyre en Aubrac | 48060 | Fau-de-Peyre | Rue des 2 Fontaines | SalÃ¨les | 80 |   | entrÃ©e | 716733.12 | 6406126.07 | 3.211423 | 44.754069 | 480090600A1396 | commune | 01/03/2023 | 1 |  




fix #170 