### PR TITLE
ajout d'un script permettant de tout composer

### DIFF
--- a/lib/compose/compose-all-force.cjs
+++ b/lib/compose/compose-all-force.cjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/* eslint no-await-in-loop: off */
+require('dotenv').config()
+const mongo = require('../util/mongo.cjs')
+const {askComposition} = require('../models/commune.cjs')
+const {getCommunes} = require('../util/cog.cjs')
+
+async function main() {
+  await mongo.connect()
+
+  const codesCommunesBAN = await mongo.db.collection('communes').distinct('codeCommune')
+  const currentCodes = new Set(codesCommunesBAN)
+
+  const communes = getCommunes().filter(c => currentCodes.has(c.code))
+
+  for (const commune of communes) {
+    await askComposition(commune.code, {force: true})
+  }
+
+  console.log('Composition forcée demandée')
+  await mongo.disconnect()
+  process.exit(0)
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "import:ftth": "node lib/import/cli.cjs ftth",
     "dist": "node lib/distribute/cli.cjs",
     "compose": "node lib/compose/cli.cjs",
+    "composeAllForce": "node lib/compose/compose-all-force.cjs",
     "lint": "xo",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "worker": "node worker.js",


### PR DESCRIPTION
Cette PR permet de composer en mettant force true à toutes les communes.
A utiliser avec parcimonie.
Elle permet de remettre à jour les communes ayant une BAL à jour en cas de correction sur le calcul du fantoir dans la BAN par exemple.