### PR TITLE
fix du problème de communes fusionnées

### DIFF
--- a/lib/compose/processors/recompute-codes-voies.cjs
+++ b/lib/compose/processors/recompute-codes-voies.cjs
@@ -11,6 +11,7 @@ async function recomputeCodesVoies(adressesCommune, fromBal) {
   }
 
   const listIdVoie = new Set()
+  const listLibelleIdVoie = new Set()
   const {codeCommune} = first(adressesCommune)
   const fantoirCommune = await createFantoirCommune(codeCommune, {fantoirPath})
 
@@ -31,12 +32,14 @@ async function recomputeCodesVoies(adressesCommune, fromBal) {
 
       if (fantoir) {
         // Avant d'attribuer le fantoir je vérifie que le couple libellé/fantoir n'apparait pas dans le set
+        const libelle = adresse.nomVoie
         const idVoie = fantoir.successeur?.replace('-', '_') || fantoir.codeCommune + '_' + fantoir.codeFantoir
-        if (fromBal && listIdVoie.has(idVoie)) {
+        if (fromBal && listIdVoie.has(idVoie) && !listLibelleIdVoie.has(libelle + idVoie)) {
           return {adresses}
         }
 
         listIdVoie.add(idVoie)
+        listLibelleIdVoie.add(libelle + idVoie)
 
         for (const adresse of adresses) {
           adresse.idVoie = idVoie


### PR DESCRIPTION
pour prendre en compte le problème de route de margeride sur la commune 48009.
On doit accepter les fusions lorsqu'on a des communes anciennes différentes même idVoie trouvé et libellé identique.