### PR TITLE
Added "ignore" patterns for nodemon/watch mechanism to improve local deployment (with and without Docker)

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,3 @@
+{   
+    "ignore": ["data/", "dist/"] 
+}

--- a/process.dev.yml
+++ b/process.dev.yml
@@ -3,7 +3,9 @@ apps:
     script : 'server.js'
     instances: '1'
     watch: true
+    ignore_watch: ['data', 'dist']
   - name : 'ban-worker'
     script : 'worker.js'
     instances: '1'
     watch: true
+    ignore_watch: ['data', 'dist']


### PR DESCRIPTION
Context : currently, the "watch" mechanism of pm2 (for Docker local deployment) and the nodemon mechanism (for local deployment not using Docker) is restarting the ban-api and/or the ban-worker when files are appearing/changing in the "dist" & "data" folder, which is not a desired behavior. 

Enhancement : a "ignore" pattern as been added : 
- to the watch mechanism in the process.dev.yml file (setting file for pm2).
- to the nodemon mechanism by adding a nodemon.json file