### PR TITLE
Postgres integration for new data schema

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,13 @@ MONGODB_URL=mongodb://127.0.0.1:27017 # Not used for deployment with Docker Comp
 MONGODB_PORT=27017 # Used only for deployment with Docker Compose
 MONGODB_DBNAME=ban
 
+# Postgres DB
+POSTGRES_URL=http://127.0.0.1:5432 # Not used for deployment with Docker Compose
+POSTGRES_PORT=5432 # Used only for deployment with Docker Compose
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DBNAME=ban
+
 # Redis
 REDIS_URL=redis://127.0.0.1:6379 # Not used for deployment with Docker Compose
 REDIS_PORT=6379 # Used only for Docker Compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,21 @@
 services:
-  db:
+  db-mongo:
     # Version of mongoDB currently in production
     image: mongo:4.2.23
     ports:
       - "${MONGODB_PORT:-27017}:27017"
     volumes:
-      - db:/data/db
+      - db-mongo:/data/db
+  db-postgres:
+    image: postgres:15-alpine
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DBNAME}
+    volumes:
+      - db-postgres:/var/lib/postgresql/data
   redis:
     # Version of Redis currently in production
     image: redis:4.0.9
@@ -15,11 +25,16 @@ services:
     build: 
       dockerfile: 'Dockerfile.dev'
     depends_on:
-      - db
+      - db-mongo
+      - db-postgres
       - redis
     environment:
-      - MONGODB_URL=mongodb://db
+      - MONGODB_URL=mongodb://db-mongo
       - MONGODB_DBNAME=${MONGODB_DBNAME}
+      - POSTGRES_URL=db-postgres
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DBNAME=${POSTGRES_DBNAME}
       - REDIS_URL=redis://redis
       - FANTOIR_PATH=${FANTOIR_PATH}
       - GAZETTEER_DB_PATH=${GAZETTEER_DB_PATH}
@@ -50,4 +65,5 @@ services:
 volumes:
   data:
   dist:
-  db:
+  db-mongo:
+  db-postgres:

--- a/lib/api/address/__mocks__/address-data-mock.js
+++ b/lib/api/address/__mocks__/address-data-mock.js
@@ -49,9 +49,6 @@ export const addressMock = [
 
 export const bddAddressMock = [
   {
-    _id: {
-      $oid: '000000000000000000000001'
-    },
     id: '00000000-0000-4fff-9fff-00000000002a',
     mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
     secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000001b', '00000000-0000-4fff-9fff-00000000001c'],
@@ -68,9 +65,6 @@ export const bddAddressMock = [
     updateDate: '2023-04-12'
   },
   {
-    _id: {
-      $oid: '000000000000000000000002'
-    },
     id: '00000000-0000-4fff-9fff-00000000002b',
     mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
     secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000001b', '00000000-0000-4fff-9fff-00000000001c'],
@@ -86,9 +80,6 @@ export const bddAddressMock = [
     updateDate: '2023-04-12'
   },
   {
-    _id: {
-      $oid: '000000000000000000000003'
-    },
     id: '00000000-0000-4fff-9fff-00000000002c',
     mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
     secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000001b', '00000000-0000-4fff-9fff-00000000001c'],

--- a/lib/api/address/models.js
+++ b/lib/api/address/models.js
@@ -1,44 +1,37 @@
-import mongo from '../../util/mongo.cjs'
-
-const COLLECTION_ADDRESS = 'address_test'
+import {Op} from 'sequelize'
+import {Address} from '../../util/sequelize.js'
 
 export async function getAddress(addressID) {
-  return mongo.db.collection(COLLECTION_ADDRESS).findOne({id: addressID})
+  return Address.findByPk(addressID, {raw: true})
 }
 
 export async function getAddresses(addressIDs) {
-  return mongo.db.collection(COLLECTION_ADDRESS).find({id: {$in: addressIDs}}).toArray()
+  return Address.findAll({where: {id: addressIDs}, raw: true})
 }
 
 export async function getAllAddressIDsFromCommune(districtID) {
-  return mongo.db.collection(COLLECTION_ADDRESS).find({districtID}).project({id: 1, _id: 0}).map(address => address.id).toArray()
+  const addresses = await Address.findAll({where: {districtID}, raw: true})
+  return addresses.map(address => address.id)
 }
 
 export async function getAllAddressIDsOutsideCommune(addressIDs, districtID) {
-  return mongo.db.collection(COLLECTION_ADDRESS).find({id: {$in: addressIDs}, districtID: {$ne: districtID}}).project({id: 1, _id: 0}).map(address => address.id).toArray()
+  const addresses = await Address.findAll({where: {id: addressIDs, districtID: {[Op.ne]: districtID}}, raw: true})
+  return addresses.map(address => address.id)
 }
 
 export async function setAddresses(addresses) {
-  return mongo.db.collection(COLLECTION_ADDRESS).insertMany(addresses)
+  return Address.bulkCreate(addresses)
 }
 
 export async function updateAddresses(addresses) {
-  const bulkOperations = addresses.map(address => {
-    const filter = {id: address.id}
-    return {
-      updateOne: {
-        filter,
-        update: {$set: address}
-      }
-    }
-  })
-  return mongo.db.collection(COLLECTION_ADDRESS).bulkWrite(bulkOperations)
+  const bulkOperations = addresses.map(address => Address.update(address, {where: {id: address.id}}))
+  return Promise.all(bulkOperations)
 }
 
 export async function deleteAddress(addressID) {
-  return mongo.db.collection(COLLECTION_ADDRESS).deleteOne({id: addressID})
+  return Address.destroy({where: {id: addressID}})
 }
 
 export async function deleteAddresses(addressIDs) {
-  return mongo.db.collection(COLLECTION_ADDRESS).deleteMany({id: {$in: addressIDs}})
+  return Address.destroy({where: {id: addressIDs}})
 }

--- a/lib/api/address/routes.js
+++ b/lib/api/address/routes.js
@@ -26,11 +26,10 @@ app.get('/:addressID', async (req, res) => {
       return
     }
 
-    const {_id, ...addressBody} = address
     response = {
       date: new Date(),
       status: 'success',
-      response: {...addressBody},
+      response: address,
     }
   } catch (error) {
     const {message} = error

--- a/lib/api/ban-id/models.js
+++ b/lib/api/ban-id/models.js
@@ -1,15 +1,11 @@
-import mongo from '../../util/mongo.cjs'
-
-const COLLECTION_ADDRESS = 'address_test'
-const COLLECTION_COMMON_TOPONYM = 'common_toponym_test'
-const COLLECTION_DISTRICT = 'district_test'
+import {Address, CommonToponym, District} from '../../util/sequelize.js'
 
 export async function idsInDataBase(ids) {
   return (
     await Promise.all([
-      mongo.db.collection(COLLECTION_ADDRESS).find({id: {$in: ids}}).toArray(),
-      mongo.db.collection(COLLECTION_COMMON_TOPONYM).find({id: {$in: ids}}).toArray(),
-      mongo.db.collection(COLLECTION_DISTRICT).find({id: {$in: ids}}).toArray()
+      Address.findAll({where: {id: ids}, raw: true}),
+      CommonToponym.findAll({where: {id: ids}, raw: true}),
+      District.findAll({where: {id: ids}, raw: true}),
     ])
   ).flat()
 }

--- a/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
+++ b/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
@@ -31,9 +31,6 @@ export const commonToponymMock = [
 
 export const bddCommonToponymMock = [
   {
-    _id: {
-      $oid: '000000000000000000000001'
-    },
     id: '00000000-0000-4fff-9fff-00000000001a',
     districtID: '00000000-0000-4fff-9fff-000000000000',
     labels: [{
@@ -48,9 +45,6 @@ export const bddCommonToponymMock = [
     updateDate: '2023-04-24'
   },
   {
-    _id: {
-      $oid: '000000000000000000000002'
-    },
     id: '00000000-0000-4fff-9fff-00000000001b',
     districtID: '00000000-0000-4fff-9fff-000000000000',
     labels: [{
@@ -65,9 +59,6 @@ export const bddCommonToponymMock = [
     updateDate: '2023-04-24'
   },
   {
-    _id: {
-      $oid: '000000000000000000000003'
-    },
     id: '00000000-0000-4fff-9fff-00000000001c',
     districtID: '00000000-0000-4fff-9fff-000000000000',
     labels: [{

--- a/lib/api/common-toponym/models.js
+++ b/lib/api/common-toponym/models.js
@@ -1,44 +1,37 @@
-import mongo from '../../util/mongo.cjs'
-
-const COLLECTION_COMMON_TOPONYM = 'commonToponym_test'
+import {Op} from 'sequelize'
+import {CommonToponym} from '../../util/sequelize.js'
 
 export async function getCommonToponym(commonToponymID) {
-  return mongo.db.collection(COLLECTION_COMMON_TOPONYM).findOne({id: commonToponymID})
+  return CommonToponym.findByPk(commonToponymID, {raw: true})
 }
 
 export async function getCommonToponyms(commonToponymIDs) {
-  return mongo.db.collection(COLLECTION_COMMON_TOPONYM).find({id: {$in: commonToponymIDs}}).toArray()
+  return CommonToponym.findAll({where: {id: commonToponymIDs}, raw: true})
 }
 
 export async function getAllCommonToponymIDsFromCommune(districtID) {
-  return mongo.db.collection(COLLECTION_COMMON_TOPONYM).find({districtID}).project({id: 1, _id: 0}).map(commonToponym => commonToponym.id).toArray()
+  const commonToponyms = await CommonToponym.findAll({where: {districtID}, raw: true})
+  return commonToponyms.map(commonToponym => commonToponym.id)
 }
 
-export async function getAllCommonToponymIDsOutsideCommune(commontToponymIDs, districtID) {
-  return mongo.db.collection(COLLECTION_COMMON_TOPONYM).find({id: {$in: commontToponymIDs}, districtID: {$ne: districtID}}).project({id: 1, _id: 0}).map(commonToponym => commonToponym.id).toArray()
+export async function getAllCommonToponymIDsOutsideCommune(commonToponymIDs, districtID) {
+  const commonToponyms = await CommonToponym.findAll({where: {id: commonToponymIDs, districtID: {[Op.ne]: districtID}}, raw: true})
+  return commonToponyms.map(commonToponym => commonToponym.id)
 }
 
 export async function setCommonToponyms(commonToponyms) {
-  return mongo.db.collection(COLLECTION_COMMON_TOPONYM).insertMany(commonToponyms)
+  return CommonToponym.bulkCreate(commonToponyms)
 }
 
 export async function updateCommonToponyms(commonToponyms) {
-  const bulkOperations = commonToponyms.map(commonToponym => {
-    const filter = {id: commonToponym.id}
-    return {
-      updateOne: {
-        filter,
-        update: {$set: commonToponym}
-      }
-    }
-  })
-  return mongo.db.collection(COLLECTION_COMMON_TOPONYM).bulkWrite(bulkOperations)
+  const bulkOperations = commonToponyms.map(commonToponym => CommonToponym.update(commonToponym, {where: {id: commonToponym.id}}))
+  return Promise.all(bulkOperations)
 }
 
 export async function deleteCommonToponym(commonToponymID) {
-  return mongo.db.collection(COLLECTION_COMMON_TOPONYM).deleteOne({id: commonToponymID})
+  return CommonToponym.destroy({where: {id: commonToponymID}})
 }
 
 export async function deleteCommonToponyms(commonToponymIDs) {
-  return mongo.db.collection(COLLECTION_COMMON_TOPONYM).deleteMany({id: {$in: commonToponymIDs}})
+  return CommonToponym.destroy({where: {id: commonToponymIDs}})
 }

--- a/lib/api/common-toponym/routes.js
+++ b/lib/api/common-toponym/routes.js
@@ -26,11 +26,10 @@ app.get('/:commonToponymID', async (req, res) => {
       return
     }
 
-    const {_id, ...commonToponymBody} = commonToponym
     response = {
       date: new Date(),
       status: 'success',
-      response: {...commonToponymBody},
+      response: commonToponym,
     }
   } catch (error) {
     const {message} = error

--- a/lib/api/district/__mocks__/district-data-mock.js
+++ b/lib/api/district/__mocks__/district-data-mock.js
@@ -29,9 +29,6 @@ export const districtMock = [
 
 export const bddDistrictMock = [
   {
-    _id: {
-      $oid: '000000000000000000000001'
-    },
     id: '00000000-0000-4fff-9fff-000000000000',
     labels: [{
       isoCode: 'fra',
@@ -45,9 +42,6 @@ export const bddDistrictMock = [
     }
   },
   {
-    _id: {
-      $oid: '000000000000000000000002'
-    },
     id: '00000000-0000-4fff-9fff-000000000001',
     labels: [{
       isoCode: 'fra',
@@ -61,9 +55,6 @@ export const bddDistrictMock = [
     }
   },
   {
-    _id: {
-      $oid: '000000000000000000000003'
-    },
     id: '00000000-0000-4fff-9fff-000000000002',
     labels: [{
       isoCode: 'fra',

--- a/lib/api/district/models.js
+++ b/lib/api/district/models.js
@@ -1,40 +1,30 @@
-import mongo from '../../util/mongo.cjs'
-
-const COLLECTION_DISTRICT = 'district_test'
+import {District} from '../../util/sequelize.js'
 
 export async function getDistrict(districtID) {
-  return mongo.db.collection(COLLECTION_DISTRICT).findOne({id: districtID})
+  return District.findByPk(districtID, {raw: true})
 }
 
 export async function getDistricts(districtIDs) {
-  return mongo.db.collection(COLLECTION_DISTRICT).find({id: {$in: districtIDs}}).toArray()
+  return District.findAll({where: {id: districtIDs}, raw: true})
 }
 
 export async function getDistrictsFromCog(cog) {
-  return mongo.db.collection(COLLECTION_DISTRICT).find({meta: {insee: {cog}}}).toArray()
+  return District.findAll({where: {meta: {insee: {cog}}}, raw: true})
 }
 
 export async function setDistricts(districts) {
-  return mongo.db.collection(COLLECTION_DISTRICT).insertMany(districts)
+  return District.bulkCreate(districts)
 }
 
 export async function updateDistricts(districts) {
-  const bulkOperations = districts.map(district => {
-    const filter = {id: district.id}
-    return {
-      updateOne: {
-        filter,
-        update: {$set: district}
-      }
-    }
-  })
-  return mongo.db.collection(COLLECTION_DISTRICT).bulkWrite(bulkOperations)
+  const promises = districts.map(district => District.update(district, {where: {id: district.id}}))
+  return Promise.all(promises)
 }
 
 export async function deleteDistrict(districtID) {
-  return mongo.db.collection(COLLECTION_DISTRICT).deleteOne({id: districtID})
+  return District.destroy({where: {id: districtID}})
 }
 
 export async function deleteDistricts(districtIDs) {
-  return mongo.db.collection(COLLECTION_DISTRICT).deleteMany({id: {$in: districtIDs}})
+  return District.destroy({where: {id: districtIDs}})
 }

--- a/lib/api/district/routes.js
+++ b/lib/api/district/routes.js
@@ -25,11 +25,10 @@ app.get('/:districtID', async (req, res) => {
       return
     }
 
-    const {_id, ...districtBody} = district
     response = {
       date: new Date(),
       status: 'success',
-      response: {...districtBody},
+      response: district,
     }
   } catch (error) {
     const {message} = error

--- a/lib/api/job-status/models.js
+++ b/lib/api/job-status/models.js
@@ -1,32 +1,20 @@
-import mongo from '../../util/mongo.cjs'
 
-const COLLECTION_JOB_STATUS = 'job_status'
+import {Op} from 'sequelize'
+import {JobStatus} from '../../util/sequelize.js'
 
 export async function getJobStatus(statusID) {
-  return mongo.db.collection(COLLECTION_JOB_STATUS).findOne({id: statusID})
+  return JobStatus.findOne({where: {id: statusID}, raw: true})
 }
 
 export async function getAllJobStatusOlderThanDate(date) {
-  return mongo.db.collection(COLLECTION_JOB_STATUS).find({createdAt: {$lte: date}}).toArray()
+  return JobStatus.findAll({where: {createdAt: {[Op.lte]: date}}, raw: true})
 }
 
 export async function setJobStatus(statusID, content) {
-  return mongo.db
-    .collection(COLLECTION_JOB_STATUS)
-    .insertOne({
-      ...content,
-      id: statusID,
-      createdAt: new Date()})
+  return JobStatus.create({id: statusID, ...content})
 }
 
 export async function deleteJobStatus(jobStatus) {
-  const bulkOperations = jobStatus.map(status => {
-    const filter = {id: status.id}
-    return {
-      deleteOne: {
-        filter
-      }
-    }
-  })
-  return mongo.db.collection(COLLECTION_JOB_STATUS).bulkWrite(bulkOperations)
+  const jobStatusIDs = jobStatus.map(status => status.id)
+  return JobStatus.destroy({where: {id: jobStatusIDs}})
 }

--- a/lib/api/job-status/routes.js
+++ b/lib/api/job-status/routes.js
@@ -1,6 +1,6 @@
 import express from 'express'
 import queue from '../../util/queue.cjs'
-import {getJobStatus} from '../job-status/models.js'
+import {getJobStatus} from './models.js'
 
 const apiQueue = queue('api')
 
@@ -18,7 +18,7 @@ app.get('/:statusID', async (req, res) => {
     } else {
       const jobStatus = await getJobStatus(statusID)
       if (jobStatus) {
-        const {_id, id, ...jobStatusBody} = jobStatus
+        const {id, ...jobStatusBody} = jobStatus
         if (jobStatusBody) {
           response = jobStatusBody
         }

--- a/lib/util/sequelize.js
+++ b/lib/util/sequelize.js
@@ -1,0 +1,155 @@
+import {Sequelize, DataTypes} from 'sequelize'
+
+// Create a new Sequelize instance
+const sequelize = new Sequelize(process.env.POSTGRES_DBNAME, process.env.POSTGRES_USER, process.env.POSTGRES_PASSWORD, {
+  host: process.env.POSTGRES_URL,
+  dialect: 'postgres',
+  logging: false
+})
+
+export const District = sequelize.define('District', {
+  id: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    primaryKey: true,
+  },
+  labels: {
+    type: DataTypes.ARRAY(DataTypes.JSONB),
+    allowNull: false,
+  },
+  updateDate: {
+    type: DataTypes.DATE,
+    allowNull: false,
+  },
+  config: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  },
+  meta: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  }
+})
+
+export const CommonToponym = sequelize.define('CommonToponym', {
+  id: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    primaryKey: true,
+  },
+  districtID: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: {
+      model: District,
+      key: 'id'
+    }
+  },
+  labels: {
+    type: DataTypes.ARRAY(DataTypes.JSONB),
+    allowNull: false,
+  },
+  type: {
+    type: DataTypes.JSONB,
+    allowNull: false,
+  },
+  geometry: {
+    type: DataTypes.JSONB,
+    allowNull: false,
+  },
+  updateDate: {
+    type: DataTypes.DATE,
+    allowNull: false,
+  },
+  meta: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  }
+})
+
+export const Address = sequelize.define('Address', {
+  id: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    primaryKey: true,
+  },
+  mainCommonToponymID: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: {
+      model: CommonToponym,
+      key: 'id'
+    }
+  },
+  secondaryCommonToponymIDs: {
+    type: DataTypes.ARRAY(DataTypes.UUID),
+  },
+  districtID: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: {
+      model: District,
+      key: 'id'
+    }
+  },
+  number: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+  },
+  suffix: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  certified: {
+    type: DataTypes.BOOLEAN,
+    allowNull: true,
+  },
+  positions: {
+    type: DataTypes.ARRAY(DataTypes.JSONB),
+    allowNull: false,
+  },
+  updateDate: {
+    type: DataTypes.DATE,
+    allowNull: false,
+  },
+  meta: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  }
+})
+
+export const JobStatus = sequelize.define('JobStatus', {
+  id: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    primaryKey: true,
+  },
+  status: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  count: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+  },
+  message: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  report: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  },
+})
+
+export const init = async () => {
+  try {
+    await sequelize.authenticate()
+    console.log('Connection has been established successfully.')
+
+    await sequelize.sync()
+    console.log('All models were synchronized successfully.')
+  } catch (error) {
+    console.error('Unable to connect to the database:', error)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -73,9 +73,11 @@
     "node-fetch": "^2.6.11",
     "ora": "^5.4.1",
     "papaparse": "^5.4.1",
+    "pg": "^8.11.0",
     "proj4": "^2.9.0",
     "pumpify": "^2.0.1",
     "rev-hash": "^3.0.0",
+    "sequelize": "^6.31.1",
     "vt-pbf": "^3.1.3",
     "worker-farm": "^1.7.0",
     "yup": "^1.0.2"
@@ -108,7 +110,8 @@
       "unicorn/no-await-expression-member": "off",
       "import/extensions": "off",
       "n/prefer-global/process": "off",
-      "n/prefer-global/buffer": "off"
+      "n/prefer-global/buffer": "off",
+      "new-cap": 0
     }
   },
   "engines": {

--- a/server.js
+++ b/server.js
@@ -4,12 +4,17 @@ import express from 'express'
 import morgan from 'morgan'
 import cors from 'cors'
 import mongo from './lib/util/mongo.cjs'
+import {init} from './lib/util/sequelize.js'
 
 import apiRoutes from './lib/api/routes.js'
 import legacyRoutes from './lib/api/legacy-routes.cjs'
 
 async function main() {
+  // Mongo DB : connecting and creating indexes
   await mongo.connect()
+
+  // Postgres DB : Testing connection and syncing models
+  await init()
 
   const app = express()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2716,6 +2716,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/debug@^4.1.7":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.8.tgz#cef723a5d0a90990313faec2d1e22aee5eecb317"
+  integrity sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/eslint@^7.2.13":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.29.0.tgz#e56ddc8e542815272720bb0b4ccc2aff9c3e1c78"
@@ -2775,6 +2782,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
+
 "@types/node@*":
   version "18.14.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.6.tgz#ae1973dd2b1eeb1825695bb11ebfb746d27e3e93"
@@ -2804,6 +2816,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/validator@^13.7.1":
+  version "13.7.17"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.17.tgz#0a6d1510395065171e3378a4afc587a3aefa7cc1"
+  integrity sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ==
 
 "@types/webidl-conversions@*":
   version "7.0.0"
@@ -3290,6 +3307,11 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer-writer@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
+  integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
 
 buffer@^5.5.0, buffer@^5.6.0:
   version "5.7.1"
@@ -3854,6 +3876,11 @@ dotenv@^16.0.1:
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
   integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
+dottie@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dottie/-/dottie-2.0.3.tgz#797a4f4c92a9a65499806be4051b9d9dcd5a5d77"
+  integrity sha512-4liA0PuRkZWQFQjwBypdxPfZaRWiv5tkhMXY2hzsa2pNf5s7U3m9cwUchfNKe8wZQxdGPQQzO6Rm2uGe0rvohQ==
 
 duplexify@^4.1.1:
   version "4.1.2"
@@ -5074,6 +5101,11 @@ infer-owner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
+
+inflection@^1.13.2:
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.13.4.tgz#65aa696c4e2da6225b148d7a154c449366633a32"
+  integrity sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -6308,7 +6340,14 @@ moment-timezone@^0.5.31:
   dependencies:
     moment "^2.29.4"
 
-moment@^2.29.4:
+moment-timezone@^0.5.35:
+  version "0.5.43"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.43.tgz#3dd7f3d0c67f78c23cd1906b9b2137a09b3c4790"
+  integrity sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==
+  dependencies:
+    moment "^2.29.4"
+
+moment@^2.29.1, moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
@@ -6726,6 +6765,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+packet-reader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
+  integrity sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
+
 pandemonium@^2.0.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/pandemonium/-/pandemonium-2.4.1.tgz#bd51ca72184c6ae135f9049a33c8605bfdb9574d"
@@ -6808,6 +6852,64 @@ pbf@^3.2.1:
     ieee754 "^1.1.12"
     resolve-protobuf-schema "^2.1.0"
 
+pg-cloudflare@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.1.0.tgz#833d70870d610d14bf9df7afb40e1cba310c17a0"
+  integrity sha512-tGM8/s6frwuAIyRcJ6nWcIvd3+3NmUKIs6OjviIm1HPPFEt5MzQDOTBQyhPWg/m0kCl95M6gA1JaIXtS8KovOA==
+
+pg-connection-string@^2.5.0, pg-connection-string@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.6.0.tgz#12a36cc4627df19c25cc1b9b736cc39ee1f73ae8"
+  integrity sha512-x14ibktcwlHKoHxx9X3uTVW9zIGR41ZB6QNhHb21OPNdCCO3NaRnpJuwKIQSR4u+Yqjx4HCvy7Hh7VSy1U4dGg==
+
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-pool@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.6.0.tgz#3190df3e4747a0d23e5e9e8045bcd99bda0a712e"
+  integrity sha512-clFRf2ksqd+F497kWFyM21tMjeikn60oGDmqMT8UBrynEwVEX/5R5xd2sdvdo1cZCFlguORNpVuqxIj+aK4cfQ==
+
+pg-protocol@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.6.0.tgz#4c91613c0315349363af2084608db843502f8833"
+  integrity sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==
+
+pg-types@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
+pg@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.11.0.tgz#a37e534e94b57a7ed811e926f23a7c56385f55d9"
+  integrity sha512-meLUVPn2TWgJyLmy7el3fQQVwft4gU5NGyvV0XbD41iU9Jbg8lCH4zexhIkihDzVHJStlt6r088G6/fWeNjhXA==
+  dependencies:
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "^2.6.0"
+    pg-pool "^3.6.0"
+    pg-protocol "^1.6.0"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+  optionalDependencies:
+    pg-cloudflare "^1.1.0"
+
+pgpass@1.x:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.5.tgz#9b873e4a564bb10fa7a7dbd55312728d422a223d"
+  integrity sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==
+  dependencies:
+    split2 "^4.1.0"
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -6865,6 +6967,28 @@ polygon-clipping@^0.15.3:
   integrity sha512-ho0Xx5DLkgxRx/+n4O74XyJ67DcyN3Tu9bGYKsnTukGAW6ssnuak6Mwcyb1wHy9MZc9xsUWqIoiazkZB5weECg==
   dependencies:
     splaytree "^3.1.0"
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+  integrity sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -7214,6 +7338,11 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+retry-as-promised@^7.0.3:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-7.0.4.tgz#9df73adaeea08cb2948b9d34990549dc13d800a2"
+  integrity sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA==
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
@@ -7321,6 +7450,33 @@ send@0.18.0:
     on-finished "2.4.1"
     range-parser "~1.2.1"
     statuses "2.0.1"
+
+sequelize-pool@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/sequelize-pool/-/sequelize-pool-7.1.0.tgz#210b391af4002762f823188fd6ecfc7413020768"
+  integrity sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==
+
+sequelize@^6.31.1:
+  version "6.31.1"
+  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-6.31.1.tgz#374bad3f0b8a9ba6a4ef15079502b4821dea1931"
+  integrity sha512-cahWtRrYLjqoZP/aurGBoaxn29qQCF4bxkAUPEQ/ozjJjt6mtL4Q113S3N39mQRmX5fgxRbli+bzZARP/N51eg==
+  dependencies:
+    "@types/debug" "^4.1.7"
+    "@types/validator" "^13.7.1"
+    debug "^4.3.3"
+    dottie "^2.0.2"
+    inflection "^1.13.2"
+    lodash "^4.17.21"
+    moment "^2.29.1"
+    moment-timezone "^0.5.35"
+    pg-connection-string "^2.5.0"
+    retry-as-promised "^7.0.3"
+    semver "^7.3.5"
+    sequelize-pool "^7.1.0"
+    toposort-class "^1.0.1"
+    uuid "^8.3.2"
+    validator "^13.7.0"
+    wkx "^0.5.0"
 
 serve-static@1.15.0:
   version "1.15.0"
@@ -7782,6 +7938,11 @@ topojson-server@3.x:
   dependencies:
     commander "2"
 
+toposort-class@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toposort-class/-/toposort-class-1.0.1.tgz#7ffd1f78c8be28c3ba45cd4e1a3f5ee193bd9988"
+  integrity sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==
+
 toposort@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
@@ -8002,6 +8163,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+validator@^13.7.0:
+  version "13.9.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.9.0.tgz#33e7b85b604f3bbce9bb1a05d5c3e22e1c2ff855"
+  integrity sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==
+
 vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -8098,6 +8264,13 @@ wkt-parser@^1.3.1:
   resolved "https://registry.yarnpkg.com/wkt-parser/-/wkt-parser-1.3.2.tgz#deeff04a21edc5b170a60da418e9ed1d1ab0e219"
   integrity sha512-A26BOOo7sHAagyxG7iuRhnKMO7Q3mEOiOT4oGUmohtN/Li5wameeU4S6f8vWw6NADTVKljBs8bzA8JPQgSEMVQ==
 
+wkx@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/wkx/-/wkx-0.5.0.tgz#c6c37019acf40e517cc6b94657a25a3d4aa33e8c"
+  integrity sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==
+  dependencies:
+    "@types/node" "*"
+
 word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
@@ -8179,7 +8352,7 @@ xo@^0.50.0:
     to-absolute-glob "^2.0.2"
     typescript "^4.7.3"
 
-xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
I. Context : Currently, the new BAN-ID data schema (address, commonToponym, district) has been deployed in the current mongoDB database in the three different collections : 
- address_test
- commonToponym_test
- district_test



II. Enhancement : 
We want to migrate this new BAN-ID data schema to a PostgreSQL data base

As a consequence, this pull request migrates the models from mongoDB to PostgreSQL with 4 tables : 'Addresses', 'CommonToponyms', 'Districts' and 'JobStatuses' (for more information about the different models, please refer to the 4 model files).

III. How to test.

1. Complete your .env file with the new variables : 

Example : 
```
POSTGRES_USER=postgres
POSTGRES_PASSWORD=postgres
POSTGRES_DBNAME=ban
POSTGRES_PORT=5432 (ONLY if your are using the docker-compose to deploy)
POSTGRES_URL=http://127.0.0.1:5432 (ONLY if your are NOT using the docker-compose to deploy)
```

2. Start the services : 

**USING DOCKER**
Start container with the following command : 
`docker-compose up --build -d`

**NOT USING DOCKER**
You can also install a postgreSQL DB on your machine and start the services as usual : 
On 2 different terminals : 
`yarn dev`
`yarn worker:dev`


3. You are all set. You can use postman to create districts, common toponyms and addresses