### PR TITLE
Add toolbox script for local dev to make a DB snapshot and compare data from snapshot and DB

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,3 +35,4 @@ JOB_STATUS_LIMIT_DURATION='90d' # Duration max of job status in database
 MAX_CONCURRENT_WORKERS=1
 DATAGOUV_API_KEY=
 PROXY_URL= # To use only if you are behind a proxy
+DISTRICT_TO_SNAPSHOT= # Comma separated list of district to snapshot (used only for dev toolbox)

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ typings/
 /dist
 /data
 
+# Toolbox
+/toolbox.dev/data
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - ./scripts:/app/scripts
       - ./server.js:/app/server.js
       - ./worker.js:/app/worker.js
+      - ./toolbox.dev:/app/toolbox.dev
 volumes:
   data:
   dist:

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,3 +1,3 @@
 {   
-    "ignore": ["data/", "dist/"] 
+    "ignore": ["data/", "dist/", "toolbox.dev/data/"] 
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "worker": "node worker.js",
     "worker:dev": "npx nodemon worker.js",
     "start": "node server.js",
-    "dev": "npx nodemon server.js"
+    "dev": "npx nodemon server.js",
+    "toolbox:snapshot":"node toolbox.dev/scripts/db-snapshot.js",
+    "toolbox:compare":"node toolbox.dev/scripts/compare-data-from-db-snapshot-and-current-db"
   },
   "dependencies": {
     "@ban-team/fantoir": "^0.15.0",
@@ -80,6 +82,7 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
+    "deep-diff": "^1.0.2",
     "jest": "^29.5.0",
     "xo": "^0.50.0"
   },

--- a/process.dev.yml
+++ b/process.dev.yml
@@ -3,9 +3,9 @@ apps:
     script : 'server.js'
     instances: '1'
     watch: true
-    ignore_watch: ['data', 'dist']
+    ignore_watch: ['data', 'dist', 'toolbox.dev/data']
   - name : 'ban-worker'
     script : 'worker.js'
     instances: '1'
     watch: true
-    ignore_watch: ['data', 'dist']
+    ignore_watch: ['data', 'dist', 'toolbox.dev/data']

--- a/start.dev.sh
+++ b/start.dev.sh
@@ -27,9 +27,9 @@ else
     npm run download-datasets
 fi
 
-npm run import:ign-api-gestion
-npm run import:cadastre
-npm run import:ftth
+# npm run import:ign-api-gestion
+# npm run import:cadastre
+# npm run import:ftth
 
 # npm run apply-batch-certification
 # npm run compose

--- a/toolbox.dev/scripts/compare-data-from-db-snapshot-and-current-db.js
+++ b/toolbox.dev/scripts/compare-data-from-db-snapshot-and-current-db.js
@@ -1,0 +1,115 @@
+import 'dotenv/config.js' // eslint-disable-line import/no-unassigned-import
+import fs from 'node:fs/promises'
+import {fileURLToPath} from 'node:url'
+import path, {dirname} from 'node:path'
+import lodash from 'lodash'
+import deepDiff from 'deep-diff'
+import mongo from '../../lib/util/mongo.cjs'
+
+const DISTRICT_TO_SNAPSHOT = (process.env.DISTRICT_TO_SNAPSHOT)?.split(',') || []
+
+const SNAPSHOT_FOLDER_NAME = 'ban-db-snapshot'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const main = async () => {
+  await mongo.connect()
+
+  // Read the files in the snapshot folder
+  const snapshotFolder = path.join(__dirname, '../data', SNAPSHOT_FOLDER_NAME)
+  const files = await fs.readdir(snapshotFolder)
+
+  // Loop through each file and compare the data with the data from the database
+  const resultPromises = files.map(async file => {
+    const collectionName = path.basename(file, '.json')
+    const collection = mongo.db.collection(collectionName)
+
+    const filePath = path.join(snapshotFolder, file)
+    const fileData = JSON.parse(await fs.readFile(filePath))
+
+    const dbData = DISTRICT_TO_SNAPSHOT
+      ? await collection.find({codeCommune: {$in: DISTRICT_TO_SNAPSHOT}}).toArray()
+      : await collection.find().toArray()
+
+    const fileDataFiltered = filterData(collectionName, fileData)
+    const dbDataFiltered = filterData(collectionName, dbData)
+
+    let report
+    const isEqual = lodash.isEqual(fileDataFiltered, dbDataFiltered)
+
+    if (!isEqual) {
+      const idKey = getIdKey(collectionName)
+      const added = {count: 0, detail: {}}
+      const modified = {count: 0, detail: {}}
+      const deleted = {count: 0, detail: {}}
+
+      // Find added and modified items
+      dbDataFiltered.forEach(item => {
+        const itemIdKey = item[idKey]
+        const fileItem = fileDataFiltered.find(fileItem => fileItem[idKey] === itemIdKey)
+        if (!fileItem) {
+          added.count++
+          added.detail[itemIdKey] = {...item}
+        } else if (!lodash.isEqual(item, fileItem)) {
+          const diff = deepDiff.diff(item, fileItem)
+          modified.count++
+          modified.detail[itemIdKey] = {...diff}
+        }
+      })
+
+      // Find deleted items
+      fileDataFiltered.forEach(item => {
+        const itemIdKey = item[idKey]
+        const dbItem = dbDataFiltered.find(dbItem => dbItem[idKey] === itemIdKey)
+        if (!dbItem) {
+          deleted.count++
+          deleted.detail[itemIdKey] = {...item}
+        }
+      })
+
+      report = {
+        added: added.count ? added : undefined,
+        modified: modified.count ? modified : undefined,
+        deleted: deleted.count ? deleted : undefined
+      }
+    }
+
+    return {collectionName, snapshotDataCount: fileData.length, dbDataCount: dbData.length, isEqual, report}
+  })
+  const results = await Promise.all(resultPromises)
+
+  // Write the result to a file
+  const resultPath = path.join(__dirname, '../data', 'compare-results.json')
+  await fs.writeFile(resultPath, JSON.stringify(results, null, 2))
+  mongo.disconnect()
+}
+
+const filterData = (collectionName, data) => {
+  if (collectionName === 'communes') {
+    return data.map(({_id, dateRevision, idRevision, composedAt, compositionAskedAt, compositionOptions, ...rest}) => ({...rest}))
+  }
+
+  if (collectionName === 'numeros') {
+    return data.map(({_id, adressesOriginales, ...rest}) => ({...rest}))
+  }
+
+  return data.map(({_id, ...rest}) => ({...rest}))
+}
+
+const getIdKey = collectionName => {
+  switch (collectionName) {
+    case 'communes':
+      return 'codeCommune'
+    case 'voies':
+      return 'idVoie'
+    case 'numeros':
+      return 'id'
+    case 'pseudo_codes_voies':
+      return 'codeVoie'
+    default:
+      return null
+  }
+}
+
+main()

--- a/toolbox.dev/scripts/db-snapshot.js
+++ b/toolbox.dev/scripts/db-snapshot.js
@@ -1,0 +1,72 @@
+import 'dotenv/config.js' // eslint-disable-line import/no-unassigned-import
+import fs from 'node:fs/promises'
+import {fileURLToPath} from 'node:url'
+import path, {dirname} from 'node:path'
+import mongo from '../../lib/util/mongo.cjs'
+
+const DISTRICT_TO_SNAPSHOT = (process.env.DISTRICT_TO_SNAPSHOT)?.split(',') || []
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const SNAPSHOT_FOLDER_NAME = 'ban-db-snapshot'
+
+const collectionNotToSnapshot = new Set(
+  ['metrics', 'sources_adresses', 'sources_voies', 'sources_communes', 'sources_parts', 'address_test', 'commonToponym_test', 'district_test', 'job_status']
+)
+
+const main = async () => {
+  console.log('Starting db snapshot script...')
+  if (DISTRICT_TO_SNAPSHOT.length > 0) {
+    console.log(`Snapshoting data for districts: ${DISTRICT_TO_SNAPSHOT.join(', ')}`)
+  } else {
+    console.log('Snapshoting all data')
+  }
+
+  await mongo.connect()
+  const initDir = path.join(__dirname, '../data', SNAPSHOT_FOLDER_NAME)
+
+  await initFolder(initDir)
+  const collections = await mongo.db.listCollections().toArray()
+  const collectionNames = collections.map(collection => collection.name)
+
+  const writeFilePromises = collectionNames.map(async collectionName => {
+    if (collectionNotToSnapshot.has(collectionName)) {
+      return
+    }
+
+    const collection = mongo.db.collection(collectionName)
+    const data = DISTRICT_TO_SNAPSHOT
+      ? await collection.find({codeCommune: {$in: DISTRICT_TO_SNAPSHOT}}).toArray()
+      : await collection.find().toArray()
+    const filePath = path.join(initDir, `${collectionName}.json`)
+    return fs.writeFile(filePath, JSON.stringify(data, null, 2))
+  })
+
+  await Promise.all(writeFilePromises)
+  mongo.disconnect()
+}
+
+async function initFolder(dir) {
+  try {
+    await fs.access(dir)
+    console.log('Data folder already exists.')
+    console.log('Deleting files inside folder.')
+    const files = await fs.readdir(dir)
+    const promises = files.map(async file => {
+      const filePath = path.join(dir, file)
+      await fs.unlink(filePath)
+    })
+    await Promise.all(promises)
+    console.log('All files deleted.')
+  } catch {
+    try {
+      await fs.mkdir(dir, {recursive: true})
+      console.log('Data folder created successfully!')
+    } catch (error) {
+      console.error(`Error creating ${dir} folder: ${error}`)
+    }
+  }
+}
+
+main()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,6 +3727,11 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
 
+deep-diff@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-1.0.2.tgz#afd3d1f749115be965e89c63edc7abb1506b9c26"
+  integrity sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==
+
 deep-equal@1.x, deep-equal@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"


### PR DESCRIPTION
I. Context : 
When making code changes locally, it is sometimes difficult to have a clear view of what is the repercussion on data processing.

II. Enhancements : 
This PR aims to add a dev toolbox at the root of the project to help the developper when coding locally. 
This toolbox is initiated with 2 scripts : 
1- `db-snapshot.js` to make a DB snapshot (DB cloned in files) => This script creates a folder where it stores all the collections in json files.
2- `compare-data-from-db-snapshot-and-current-db` to compare the data from the snapshot and from the current DB running locally => This script reads the files from the snapshot, read the data in the current DB and builds a report to inform the developper what has been added, deleted and modified.

Example of use : 
"I would like to refactorize the legacy code that process a BAL and insert it in the BAN DB. The code doing that is quite complexe and I don't have a full understanding of all the repercussion of one code change. With those two scripts, I can make a snapshot of the DB before doing any code changes, make the changes, reprocess the data and compare the data from the initial snapshot and the DB. As a consequence, I can clearly see the data has been added, deleted, modified."

III. How to test it : 

You can simply start those two commands : 

`yarn toolbox:snapshot`

`yarn toolbox:compare`

If you want to do the snapshot and compare ONLY for one district, you can add the following env variable in your .env file : 

`DISTRICT_TO_SNAPSHOT=77139`