### PR TITLE
Modified BAN-ID data schema

### DIFF
--- a/lib/api/address/__mocks__/address-data-mock.js
+++ b/lib/api/address/__mocks__/address-data-mock.js
@@ -6,7 +6,7 @@ export const addressMock = [
     districtID: '00000000-0000-4fff-9fff-00000000003a',
     number: 1,
     positions: [{
-      type: 'entrée',
+      type: 'entrance',
       geometry: {
         type: 'Point',
         coordinates: [1.23, 2.34]
@@ -22,7 +22,7 @@ export const addressMock = [
     number: 1,
     suffix: 'bis',
     positions: [{
-      type: 'entrée',
+      type: 'entrance',
       geometry: {
         type: 'Point',
         coordinates: [1.24, 2.34]
@@ -37,7 +37,7 @@ export const addressMock = [
     districtID: '00000000-0000-4fff-9fff-00000000003a',
     number: 2,
     positions: [{
-      type: 'entrée',
+      type: 'entrance',
       geometry: {
         type: 'Point',
         coordinates: [1.25, 2.34]
@@ -59,7 +59,7 @@ export const bddAddressMock = [
     number: 10,
     suffix: 'ter',
     positions: [{
-      type: 'entrée',
+      type: 'entrance',
       geometry: {
         type: 'Point',
         coordinates: [1.25, 2.34]
@@ -77,7 +77,7 @@ export const bddAddressMock = [
     districtID: '00000000-0000-4fff-9fff-00000000003a',
     number: 15,
     positions: [{
-      type: 'entrée',
+      type: 'entrance',
       geometry: {
         type: 'Point',
         coordinates: [1.25, 2.34]
@@ -95,7 +95,7 @@ export const bddAddressMock = [
     districtID: '00000000-0000-4fff-9fff-00000000003a',
     number: 6,
     positions: [{
-      type: 'entrée',
+      type: 'entrance',
       geometry: {
         type: 'Point',
         coordinates: [1.25, 2.34]

--- a/lib/api/address/__mocks__/address-data-mock.js
+++ b/lib/api/address/__mocks__/address-data-mock.js
@@ -1,8 +1,9 @@
 export const addressMock = [
   {
     id: '00000000-0000-4fff-9fff-00000000000a',
-    districtID: '12345',
-    commonToponymID: '00000000-0000-4fff-9fff-00000000001a',
+    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     number: 1,
     positions: [{
       type: 'entrée',
@@ -15,8 +16,9 @@ export const addressMock = [
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
-    districtID: '12345',
-    commonToponymID: '00000000-0000-4fff-9fff-00000000001a',
+    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     number: 1,
     suffix: 'bis',
     positions: [{
@@ -30,8 +32,9 @@ export const addressMock = [
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000c',
-    districtID: '12345',
-    commonToponymID: '00000000-0000-4fff-9fff-00000000001a',
+    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     number: 2,
     positions: [{
       type: 'entrée',
@@ -50,8 +53,9 @@ export const bddAddressMock = [
       $oid: '000000000000000000000001'
     },
     id: '00000000-0000-4fff-9fff-000000000000',
-    districtID: '12345',
-    commonToponymID: '00000000-0000-4fff-9fff-00000000001b',
+    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001b',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     number: 10,
     suffix: 'ter',
     positions: [{
@@ -68,8 +72,9 @@ export const bddAddressMock = [
       $oid: '000000000000000000000002'
     },
     id: '00000000-0000-4fff-9fff-000000000001',
-    districtID: '12345',
-    commonToponymID: '00000000-0000-4fff-9fff-00000000001b',
+    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001b',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     number: 15,
     positions: [{
       type: 'entrée',
@@ -85,8 +90,9 @@ export const bddAddressMock = [
       $oid: '000000000000000000000003'
     },
     id: '00000000-0000-4fff-9fff-000000000002',
-    districtID: '12345',
-    commonToponymID: '00000000-0000-4fff-9fff-00000000001b',
+    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001b',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     number: 6,
     positions: [{
       type: 'entrée',

--- a/lib/api/address/schema.js
+++ b/lib/api/address/schema.js
@@ -1,28 +1,27 @@
 import {object, string, number, boolean, array} from 'yup'
+import {banID, geometrySchema, cadastreSchema} from '../schema.js'
 
-const geometrySchema = object({
-  type: string().trim().matches(/^Point$/).required(),
-  coordinates: array().length(2).of(number()).required(),
-})
-
-const PositionTypes = ['entrée', 'bâtiment', 'cage d\'escalier', 'logement', 'service technique', 'délivrance postale', 'parcelle', 'segment', 'autre']
+const PositionTypes = ['entrance', 'building', 'staircase identifier', 'unit identifier', 'utility service', 'postal delivery', 'parcel', 'segment', 'other']
 
 const positionSchema = object({
   type: string().trim().oneOf(PositionTypes).required(),
   geometry: geometrySchema.required(),
 })
 
-export const banID = string().trim().uuid()
+const metaSchema = object({
+  cadastre: cadastreSchema
+})
 
 export const banAddressSchema = object({
   id: banID.required(),
-  districtID: string().trim().required(),
-  commonToponymID: string().trim().required(),
+  mainCommonToponymID: banID.required(),
+  secondaryCommonToponymIDs: array().of(banID),
+  districtID: banID.required(),
   number: number().positive().integer().required(),
   suffix: string().trim(),
-  parcels: array().of(string().trim()),
   certified: boolean(),
   positions: array().of(positionSchema),
   updateDate: string().trim().required(),
+  meta: metaSchema
 })
 

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -1,6 +1,7 @@
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema} from '../helper.js'
+import {banID} from '../schema.js'
 import {getAddresses, getAllAddressIDsFromCommune, getAllAddressIDsOutsideCommune} from './models.js'
-import {banAddressSchema, banID} from './schema.js'
+import {banAddressSchema} from './schema.js'
 
 const getExistingAddressIDs = async addressIDs => {
   const existingAddresses = await getAddresses(addressIDs)

--- a/lib/api/ban-id/models.js
+++ b/lib/api/ban-id/models.js
@@ -2,12 +2,14 @@ import mongo from '../../util/mongo.cjs'
 
 const COLLECTION_ADDRESS = 'address_test'
 const COLLECTION_COMMON_TOPONYM = 'common_toponym_test'
+const COLLECTION_DISTRICT = 'district_test'
 
 export async function idsInDataBase(ids) {
   return (
     await Promise.all([
       mongo.db.collection(COLLECTION_ADDRESS).find({id: {$in: ids}}).toArray(),
-      mongo.db.collection(COLLECTION_COMMON_TOPONYM).find({id: {$in: ids}}).toArray()
+      mongo.db.collection(COLLECTION_COMMON_TOPONYM).find({id: {$in: ids}}).toArray(),
+      mongo.db.collection(COLLECTION_DISTRICT).find({id: {$in: ids}}).toArray()
     ])
   ).flat()
 }

--- a/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
+++ b/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
@@ -1,7 +1,7 @@
 export const commonToponymMock = [
   {
     id: '00000000-0000-4fff-9fff-00000000000a',
-    districtID: '12345',
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     label: [{
       isoCode: 'fra',
       value: 'Rue de la baleine'
@@ -15,7 +15,7 @@ export const commonToponymMock = [
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
-    districtID: '12345',
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     label: [{
       isoCode: 'fra',
       value: 'Rue de la baleine'
@@ -35,7 +35,7 @@ export const bddCommonToponymMock = [
       $oid: '000000000000000000000001'
     },
     id: '00000000-0000-4fff-9fff-000000000000',
-    districtID: '12345',
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     label: [{
       isoCode: 'fra',
       value: 'Rue du Renard'
@@ -52,7 +52,7 @@ export const bddCommonToponymMock = [
       $oid: '000000000000000000000002'
     },
     id: '00000000-0000-4fff-9fff-000000000001',
-    districtID: '12345',
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     label: [{
       isoCode: 'fra',
       value: 'Rue du Renard'
@@ -69,7 +69,7 @@ export const bddCommonToponymMock = [
       $oid: '000000000000000000000003'
     },
     id: '00000000-0000-4fff-9fff-000000000002',
-    districtID: '12345',
+    districtID: '00000000-0000-4fff-9fff-00000000003a',
     label: [{
       isoCode: 'fra',
       value: 'Rue du Renard'

--- a/lib/api/common-toponym/models.js
+++ b/lib/api/common-toponym/models.js
@@ -32,7 +32,6 @@ export async function updateCommonToponyms(commonToponyms) {
       }
     }
   })
-  // TODO: Use status or historic collection for conserve event trace.
   return mongo.db.collection(COLLECTION_COMMON_TOPONYM).bulkWrite(bulkOperations)
 }
 

--- a/lib/api/common-toponym/schema.js
+++ b/lib/api/common-toponym/schema.js
@@ -1,11 +1,5 @@
-import {object, string, array, number} from 'yup'
-
-export const banCommonToponymID = string().trim().uuid()
-
-const labelSchema = object({
-  isoCode: string().trim().length(3).required(),
-  value: string().trim().required(),
-})
+import {object, string, array} from 'yup'
+import {banID, geometrySchema, labelSchema, cadastreSchema} from '../schema.js'
 
 const typeValues = ['voie', 'lieu-dit', 'autre']
 
@@ -14,17 +8,16 @@ const typeSchema = object({
   value: string().trim().oneOf(typeValues).required(),
 })
 
-const geometrySchema = object({
-  type: string().trim().matches(/^Point$/).required(),
-  coordinates: array().length(2).of(number()).required(),
+const metaSchema = object({
+  cadastre: cadastreSchema
 })
 
 export const banCommonToponymSchema = object({
-  id: banCommonToponymID.required(),
-  districtID: string().trim().required(),
+  id: banID.required(),
+  districtID: banID.required(),
   label: array().of(labelSchema).required(),
   type: typeSchema.required(),
-  parcels: array().of(string().trim()),
   geometry: geometrySchema.required(),
   updateDate: string().trim().required(),
+  meta: metaSchema
 })

--- a/lib/api/common-toponym/utils.js
+++ b/lib/api/common-toponym/utils.js
@@ -1,6 +1,7 @@
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema} from '../helper.js'
+import {banID} from '../schema.js'
 import {getCommonToponyms, getAllCommonToponymIDsFromCommune, getAllCommonToponymIDsOutsideCommune} from './models.js'
-import {banCommonToponymSchema, banCommonToponymID} from './schema.js'
+import {banCommonToponymSchema} from './schema.js'
 
 const getExistingCommonToponymIDs = async commonToponymIDs => {
   const existingCommonToponyms = await getCommonToponyms(commonToponymIDs)
@@ -12,7 +13,7 @@ export const checkCommonToponymsIDsRequest = async (commonToponymIDs, actionType
     `The request require an Array of common toponym IDs but receive ${typeof commonToponymIDs}`,
     'No common toponym ID send to job',
     commonToponymIDs
-  ) || await checkIdsShema('Invalid IDs format', commonToponymIDs, banCommonToponymID)
+  ) || await checkIdsShema('Invalid IDs format', commonToponymIDs, banID)
 
   if (!report) {
     switch (actionType) {

--- a/lib/api/district/__mocks__/district-data-mock.js
+++ b/lib/api/district/__mocks__/district-data-mock.js
@@ -4,14 +4,26 @@ export const districtMock = [
     label: [{
       isoCode: 'fra',
       value: 'Commune A'
-    }]
+    }],
+    updateDate: '2023-06-22',
+    meta: {
+      insee: {
+        cog: '12345'
+      }
+    }
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
     label: [{
       isoCode: 'fra',
       value: 'Commune B'
-    }]
+    }],
+    updateDate: '2023-06-22',
+    meta: {
+      insee: {
+        cog: '12346'
+      }
+    }
   },
 ]
 
@@ -24,7 +36,13 @@ export const bddDistrictMock = [
     label: [{
       isoCode: 'fra',
       value: 'Commune C'
-    }]
+    }],
+    updateDate: '2023-06-22',
+    meta: {
+      insee: {
+        cog: '54321'
+      }
+    }
   },
   {
     _id: {
@@ -34,7 +52,13 @@ export const bddDistrictMock = [
     label: [{
       isoCode: 'fra',
       value: 'Commune D'
-    }]
+    }],
+    updateDate: '2023-06-22',
+    meta: {
+      insee: {
+        cog: '54322'
+      }
+    }
   },
   {
     _id: {
@@ -44,6 +68,12 @@ export const bddDistrictMock = [
     label: [{
       isoCode: 'fra',
       value: 'Commune E'
-    }]
+    }],
+    updateDate: '2023-06-22',
+    meta: {
+      insee: {
+        cog: '54323'
+      }
+    }
   }
 ]

--- a/lib/api/district/schema.js
+++ b/lib/api/district/schema.js
@@ -1,13 +1,13 @@
-import {object, string, array} from 'yup'
+import {object, array, string} from 'yup'
+import {banID, labelSchema, inseeSchema} from '../schema.js'
 
-export const banDistrictID = string().trim().uuid()
-
-const labelSchema = object({
-  isoCode: string().trim().length(3).required(),
-  value: string().trim().required(),
+const metaSchema = object({
+  insee: inseeSchema
 })
 
 export const banDistrictSchema = object({
-  id: banDistrictID.required(),
+  id: banID.required(),
   label: array().of(labelSchema).required(),
+  updateDate: string().trim().required(),
+  meta: metaSchema
 })

--- a/lib/api/district/utils.js
+++ b/lib/api/district/utils.js
@@ -1,6 +1,7 @@
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema} from '../helper.js'
+import {banID} from '../schema.js'
 import {getDistricts} from './models.js'
-import {banDistrictSchema, banDistrictID} from './schema.js'
+import {banDistrictSchema} from './schema.js'
 
 const getExistingDistrictIDs = async districtIDs => {
   const existingDistricts = await getDistricts(districtIDs)
@@ -12,7 +13,7 @@ export const checkDistrictsIDsRequest = async (districtIDs, actionType, defaultR
     `The request require an Array of district IDs but receive ${typeof districtIDs}`,
     'No district ID send to job',
     districtIDs
-  ) || await checkIdsShema('Invalid IDs format', districtIDs, banDistrictID)
+  ) || await checkIdsShema('Invalid IDs format', districtIDs, banID)
 
   if (!report) {
     switch (actionType) {

--- a/lib/api/schema.js
+++ b/lib/api/schema.js
@@ -1,0 +1,21 @@
+import {object, string, number, array} from 'yup'
+
+export const banID = string().trim().uuid()
+
+export const labelSchema = object({
+  isoCode: string().trim().length(3).required(),
+  value: string().trim().required(),
+})
+
+export const geometrySchema = object({
+  type: string().trim().matches(/^Point$/).required(),
+  coordinates: array().length(2).of(number()).required(),
+})
+
+export const inseeSchema = object({
+  cog: string().trim().length(5).required()
+})
+
+export const cadastreSchema = object({
+  ids: array().of(string().trim())
+})


### PR DESCRIPTION
I. Context : 
As our specification begins to get clearer, we need to modify the current BAN-ID data schema. 

==> **[Here is the up-to-date specification for BAN-ID data schema](https://github.com/BaseAdresseNationale/ban-plateforme/wiki/DRAFT%23-Schema-de-la-base-de-donn%C3%A9es-BAN)** <==

II. Enhancements : 
In the current schema, this PR is : 
- adding the "mainCommonToponymID" and "secondaryCommonToponymIDs" fields on address schema,
- adding the "meta" field in Address/CommonToponym/District (in which we will add the data relative to other organisms as Insee, cadastre, ...),
- modifying the position type list to fit INSPIRE equivalent,
- adding "updateDate" on CommonToponym and District (as a required field).

This PR also unify the UUID for all IDs (address, commonToponym, district)