### PR TITLE
Added route to get dristricts from cog

### DIFF
--- a/lib/api/district/models.js
+++ b/lib/api/district/models.js
@@ -2,35 +2,39 @@ import mongo from '../../util/mongo.cjs'
 
 const COLLECTION_DISTRICT = 'district_test'
 
-export async function getDistrict(disrtrictID) {
-  return mongo.db.collection(COLLECTION_DISTRICT).findOne({id: disrtrictID})
+export async function getDistrict(districtID) {
+  return mongo.db.collection(COLLECTION_DISTRICT).findOne({id: districtID})
 }
 
-export async function getDistricts(disrtrictIDs) {
-  return mongo.db.collection(COLLECTION_DISTRICT).find({id: {$in: disrtrictIDs}}).toArray()
+export async function getDistricts(districtIDs) {
+  return mongo.db.collection(COLLECTION_DISTRICT).find({id: {$in: districtIDs}}).toArray()
 }
 
-export async function setDistricts(disrtricts) {
-  return mongo.db.collection(COLLECTION_DISTRICT).insertMany(disrtricts)
+export async function getDistrictsFromCog(cog) {
+  return mongo.db.collection(COLLECTION_DISTRICT).find({meta: {insee: {cog}}}).toArray()
 }
 
-export async function updateDistricts(disrtricts) {
-  const bulkOperations = disrtricts.map(disrtrict => {
-    const filter = {id: disrtrict.id}
+export async function setDistricts(districts) {
+  return mongo.db.collection(COLLECTION_DISTRICT).insertMany(districts)
+}
+
+export async function updateDistricts(districts) {
+  const bulkOperations = districts.map(district => {
+    const filter = {id: district.id}
     return {
       updateOne: {
         filter,
-        update: {$set: disrtrict}
+        update: {$set: district}
       }
     }
   })
   return mongo.db.collection(COLLECTION_DISTRICT).bulkWrite(bulkOperations)
 }
 
-export async function deleteDistrict(disrtrictID) {
-  return mongo.db.collection(COLLECTION_DISTRICT).deleteOne({id: disrtrictID})
+export async function deleteDistrict(districtID) {
+  return mongo.db.collection(COLLECTION_DISTRICT).deleteOne({id: districtID})
 }
 
-export async function deleteDistricts(disrtrictIDs) {
-  return mongo.db.collection(COLLECTION_DISTRICT).deleteMany({id: {$in: disrtrictIDs}})
+export async function deleteDistricts(districtIDs) {
+  return mongo.db.collection(COLLECTION_DISTRICT).deleteMany({id: {$in: districtIDs}})
 }

--- a/lib/api/district/routes.js
+++ b/lib/api/district/routes.js
@@ -3,7 +3,7 @@ import {customAlphabet} from 'nanoid'
 import express from 'express'
 import queue from '../../util/queue.cjs'
 import auth from '../../middleware/auth.js'
-import {getDistrict, deleteDistrict} from './models.js'
+import {getDistrict, getDistrictsFromCog, deleteDistrict} from './models.js'
 
 const apiQueue = queue('api')
 
@@ -31,6 +31,36 @@ app.get('/:districtID', async (req, res) => {
       date: new Date(),
       status: 'success',
       response: {...districtBody},
+    }
+  } catch (error) {
+    const {message} = error
+    response = {
+      date: new Date(),
+      status: 'error',
+      message,
+      response: {},
+    }
+  }
+
+  res.send(response)
+})
+
+app.get('/cog/:cog', async (req, res) => {
+  let response
+  try {
+    const {cog} = req.params
+    const districts = await getDistrictsFromCog(cog)
+
+    if (!districts || districts.length === 0) {
+      res.status(404).send('Request ID unknown')
+      return
+    }
+
+    const districtBodies = districts.map(({_id, ...districtBody}) => districtBody)
+    response = {
+      date: new Date(),
+      status: 'success',
+      response: districtBodies,
     }
   } catch (error) {
     const {message} = error


### PR DESCRIPTION
I. Context : 
In order for data producers to be able to get districts (and especially districtIDs) from the cog ("code officiel géographique" or also "code commune"), we need to expose a new api route.

II. Enhancements : 
This PR aims to add this following api route : 
`GET district/cog/:cog` ==> No tokens required.


Example of request : 
`GET district/cog/12345`

Example of response with code 200 : 
```
[
  {
    "id": "00000000-0000-4fff-9fff-00000000000a",
    "label": [
      {
        "isoCode": "fra",
        "value": "commune de 12345"
      }
    ],
    "updateDate": "2023-06-23",
    "meta": {
      "insee": {
      "cog": "12345"
      }
    }
  }
]
```