### PR TITLE
Added checks on common toponym and district existences in db

### DIFF
--- a/lib/api/address/__mocks__/address-data-mock.js
+++ b/lib/api/address/__mocks__/address-data-mock.js
@@ -2,8 +2,8 @@ export const addressMock = [
   {
     id: '00000000-0000-4fff-9fff-00000000000a',
     mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
-    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000001b', '00000000-0000-4fff-9fff-00000000001c'],
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     number: 1,
     positions: [{
       type: 'entrance',
@@ -17,8 +17,8 @@ export const addressMock = [
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
     mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
-    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000001b', '00000000-0000-4fff-9fff-00000000001c'],
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     number: 1,
     suffix: 'bis',
     positions: [{
@@ -33,8 +33,8 @@ export const addressMock = [
   {
     id: '00000000-0000-4fff-9fff-00000000000c',
     mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
-    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000001b', '00000000-0000-4fff-9fff-00000000001c'],
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     number: 2,
     positions: [{
       type: 'entrance',
@@ -52,10 +52,10 @@ export const bddAddressMock = [
     _id: {
       $oid: '000000000000000000000001'
     },
-    id: '00000000-0000-4fff-9fff-000000000000',
-    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001b',
-    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    id: '00000000-0000-4fff-9fff-00000000002a',
+    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000001b', '00000000-0000-4fff-9fff-00000000001c'],
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     number: 10,
     suffix: 'ter',
     positions: [{
@@ -71,10 +71,10 @@ export const bddAddressMock = [
     _id: {
       $oid: '000000000000000000000002'
     },
-    id: '00000000-0000-4fff-9fff-000000000001',
-    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001b',
-    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    id: '00000000-0000-4fff-9fff-00000000002b',
+    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000001b', '00000000-0000-4fff-9fff-00000000001c'],
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     number: 15,
     positions: [{
       type: 'entrance',
@@ -89,10 +89,10 @@ export const bddAddressMock = [
     _id: {
       $oid: '000000000000000000000003'
     },
-    id: '00000000-0000-4fff-9fff-000000000002',
-    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001b',
-    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000002a'],
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    id: '00000000-0000-4fff-9fff-00000000002c',
+    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001a',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000001b', '00000000-0000-4fff-9fff-00000000001c'],
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     number: 6,
     positions: [{
       type: 'entrance',

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -1,4 +1,4 @@
-import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema} from '../helper.js'
+import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfCommonToponymsExist, checkIfDistrictsExist} from '../helper.js'
 import {banID} from '../schema.js'
 import {getAddresses, getAllAddressIDsFromCommune, getAllAddressIDsOutsideCommune} from './models.js'
 import {banAddressSchema} from './schema.js'
@@ -56,6 +56,15 @@ export const checkAddressesRequest = async (addresses, actionType) => {
       )
         || await checkAddressesIDsRequest(addresses.map(address => address.id), actionType, false)
         || await checkDataShema('Invalid format', addresses, banAddressSchema)
+        || await checkIfCommonToponymsExist(addresses.reduce((acc, {mainCommonToponymID, secondaryCommonToponymIDs}) => {
+          const ids = [mainCommonToponymID]
+          if (secondaryCommonToponymIDs) {
+            ids.push(...secondaryCommonToponymIDs)
+          }
+
+          return [...acc, ...ids]
+        }, []))
+        || await checkIfDistrictsExist(addresses.map(({districtID}) => districtID))
         || dataValidationReportFrom(true)
       break
     default:

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -3,6 +3,8 @@ import {object, string, bool, array} from 'yup'
 import {addressMock, bddAddressMock} from './__mocks__/address-data-mock.js'
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/address-models.js'))
+jest.unstable_mockModule('../common-toponym/models.js', async () => import('../common-toponym/__mocks__/common-toponym-models.js'))
+jest.unstable_mockModule('../district/models.js', async () => import('../district/__mocks__/district-models.js'))
 const {checkAddressesIDsRequest, checkAddressesRequest} = await import('./utils.js')
 
 const addressesValidationSchema = object({

--- a/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
+++ b/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
@@ -1,7 +1,7 @@
 export const commonToponymMock = [
   {
     id: '00000000-0000-4fff-9fff-00000000000a',
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     labels: [{
       isoCode: 'fra',
       value: 'Rue de la baleine'
@@ -15,7 +15,7 @@ export const commonToponymMock = [
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     labels: [{
       isoCode: 'fra',
       value: 'Rue de la baleine'
@@ -34,8 +34,8 @@ export const bddCommonToponymMock = [
     _id: {
       $oid: '000000000000000000000001'
     },
-    id: '00000000-0000-4fff-9fff-000000000000',
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    id: '00000000-0000-4fff-9fff-00000000001a',
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     labels: [{
       isoCode: 'fra',
       value: 'Rue du Renard'
@@ -51,8 +51,8 @@ export const bddCommonToponymMock = [
     _id: {
       $oid: '000000000000000000000002'
     },
-    id: '00000000-0000-4fff-9fff-000000000001',
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    id: '00000000-0000-4fff-9fff-00000000001b',
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     labels: [{
       isoCode: 'fra',
       value: 'Rue du Renard'
@@ -68,8 +68,8 @@ export const bddCommonToponymMock = [
     _id: {
       $oid: '000000000000000000000003'
     },
-    id: '00000000-0000-4fff-9fff-000000000002',
-    districtID: '00000000-0000-4fff-9fff-00000000003a',
+    id: '00000000-0000-4fff-9fff-00000000001c',
+    districtID: '00000000-0000-4fff-9fff-000000000000',
     labels: [{
       isoCode: 'fra',
       value: 'Rue du Renard'

--- a/lib/api/common-toponym/utils.js
+++ b/lib/api/common-toponym/utils.js
@@ -1,4 +1,4 @@
-import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema} from '../helper.js'
+import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfDistrictsExist} from '../helper.js'
 import {banID} from '../schema.js'
 import {getCommonToponyms, getAllCommonToponymIDsFromCommune, getAllCommonToponymIDsOutsideCommune} from './models.js'
 import {banCommonToponymSchema} from './schema.js'
@@ -56,6 +56,7 @@ export const checkCommonToponymsRequest = async (commonToponyms, actionType) => 
       )
         || await checkCommonToponymsIDsRequest(commonToponyms.map(commonToponym => commonToponym.id), actionType, false)
         || await checkDataShema('Invalid common toponym format', commonToponyms, banCommonToponymSchema)
+        || await checkIfDistrictsExist(commonToponyms.map(({districtID}) => districtID))
         || dataValidationReportFrom(true)
       break
     default:

--- a/lib/api/common-toponym/utils.spec.js
+++ b/lib/api/common-toponym/utils.spec.js
@@ -3,6 +3,7 @@ import {object, string, bool, array} from 'yup'
 import {commonToponymMock, bddCommonToponymMock} from './__mocks__/common-toponym-data-mock.js'
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/common-toponym-models.js'))
+jest.unstable_mockModule('../district/models.js', async () => import('../district/__mocks__/district-models.js'))
 const {checkCommonToponymsRequest, checkCommonToponymsIDsRequest} = await import('./utils.js')
 
 const commonToponymsValidationSchema = object({

--- a/lib/api/helper.js
+++ b/lib/api/helper.js
@@ -1,3 +1,6 @@
+import {getCommonToponyms} from './common-toponym/models.js'
+import {getDistricts} from './district/models.js'
+
 export const dataValidationReportFrom = (isValid, message, data) => ({
   isValid,
   ...(message || data
@@ -88,5 +91,25 @@ export const checkDataShema = async (err = 'Invalid data format', dataArr, schem
   const invalidDataArr = dataArrValidation.filter(({isValid}) => !isValid)
   if (invalidDataArr.length > 0) {
     return dataValidationReportFrom(false, err, invalidDataArr)
+  }
+}
+
+export const checkIfCommonToponymsExist = async commonToponymIDs => {
+  const uniqCommonToponymIDs = [...new Set(commonToponymIDs)]
+  const existingCommonToponyms = await getCommonToponyms(uniqCommonToponymIDs)
+  if (uniqCommonToponymIDs.length !== existingCommonToponyms.length) {
+    const existingCommonToponymIDSet = new Set(existingCommonToponyms.map(({id}) => id))
+    const nonExistingCommonToponymIDs = uniqCommonToponymIDs.filter(id => !existingCommonToponymIDSet.has(id))
+    return dataValidationReportFrom(false, 'Some common toponyms do not exist', nonExistingCommonToponymIDs)
+  }
+}
+
+export const checkIfDistrictsExist = async districtIDs => {
+  const uniqDistrictIDs = [...new Set(districtIDs)]
+  const existingDistricts = await getDistricts(uniqDistrictIDs)
+  if (uniqDistrictIDs.length !== existingDistricts.length) {
+    const existingDistrictIDs = new Set(existingDistricts.map(({id}) => id))
+    const nonExistingCommonToponymIDs = uniqDistrictIDs.filter(id => !existingDistrictIDs.has(id))
+    return dataValidationReportFrom(false, 'Some districts do not exist', nonExistingCommonToponymIDs)
   }
 }


### PR DESCRIPTION
I. Context 

When creating and/or updating common toponyms and/or addresses, we need to be able to check if the linked common toponym IDs and the linked district IDs are already existing in the db.

II. Enhancements 

This PR aims to add two check functions to be sure that the linked commonToponyms (main and secondaries) and the linked district are pre-existing in the DB