### PR TITLE
Modified ban api url in .env.sample file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,7 +9,7 @@ REDIS_PORT=6379 # Used only for Docker Compose
 
 # APIs
 # API BAN
-BAN_API_URL=https://plateforme.adresse.data.gouv.fr
+BAN_API_URL=https://plateforme.adresse.data.gouv.fr/api
 ADMIN_TOKEN=  # Used for legacy routes
 BAN_API_AUTHORIZED_TOKENS= # Used for new ban-id api routes
 PORT=5000

--- a/lib/api/address/routes.js
+++ b/lib/api/address/routes.js
@@ -9,7 +9,7 @@ import {getDeltaReport} from './utils.js'
 const apiQueue = queue('api')
 
 const BAN_API_URL
-  = process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr'
+  = process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr/api'
 
 const nanoid = customAlphabet('123456789ABCDEFGHJKMNPQRSTVWXYZ', 9)
 

--- a/lib/api/common-toponym/routes.js
+++ b/lib/api/common-toponym/routes.js
@@ -9,7 +9,7 @@ import {getDeltaReport} from './utils.js'
 const apiQueue = queue('api')
 
 const BAN_API_URL
-  = process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr'
+  = process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr/api'
 
 const nanoid = customAlphabet('123456789ABCDEFGHJKMNPQRSTVWXYZ', 9)
 

--- a/lib/api/district/routes.js
+++ b/lib/api/district/routes.js
@@ -8,7 +8,7 @@ import {getDistrict, getDistrictsFromCog, deleteDistrict} from './models.js'
 const apiQueue = queue('api')
 
 const BAN_API_URL
-  = process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr'
+  = process.env.BAN_API_URL || 'https://plateforme.adresse.data.gouv.fr/api'
 
 const nanoid = customAlphabet('123456789ABCDEFGHJKMNPQRSTVWXYZ', 9)
 


### PR DESCRIPTION
Fix on BAN api url that has been modified from `https://plateforme.adresse.data.gouv.fr` to `https://plateforme.adresse.data.gouv.fr/api`