### PR TITLE
Added config in the district schema

### DIFF
--- a/lib/api/district/schema.js
+++ b/lib/api/district/schema.js
@@ -1,5 +1,9 @@
-import {object, array, string} from 'yup'
+import {object, array, string, bool} from 'yup'
 import {banID, labelSchema, inseeSchema} from '../schema.js'
+
+const configSchema = object({
+  useBanId: bool()
+})
 
 const metaSchema = object({
   insee: inseeSchema
@@ -9,5 +13,6 @@ export const banDistrictSchema = object({
   id: banID.required(),
   labels: array().of(labelSchema).required(),
   updateDate: string().trim().required(),
+  config: configSchema,
   meta: metaSchema
 })


### PR DESCRIPTION
This PR aims to add a `config` key in the district schema to add configuration per district (defaultLanguages, useBanId, ... etc).

Here is the district schema : 

```
banDistrictSchema = object({
  id: banID.required(),
  labels: array().of(labelSchema).required(),
  updateDate: string().trim().required(),
  config: configSchema,
  meta: metaSchema
})
```

And the config schema (for now) : 
```
configSchema = object({
  useBanId: bool()
})
```