### PR TITLE
Fix compose when extract district id

### DIFF
--- a/lib/compose/index.cjs
+++ b/lib/compose/index.cjs
@@ -114,8 +114,11 @@ async function composeCommune(codeCommune) {
   const nbNumeros = voies.reduce((acc, voie) => acc + voie.nbNumeros, 0)
   const nbNumerosCertifies = numeros.filter(n => n.certifie).length
 
-  const {uidAdresse} = balData.adresses[0]
-  const {districtID} = digestIDsFromBalUIDs(uidAdresse)
+  let districtID
+  if (isBAL) {
+    const {uidAdresse} = balData.adresses[0]
+    districtID = digestIDsFromBalUIDs(uidAdresse)?.districtID
+  }
 
   const communeRecord = {
     banId: districtID,


### PR DESCRIPTION
I. Context 

When doing a "compose" for a non-BAL district, the balData and uid_adresse do not exist. 

II. Fix 

Condition the extraction of the district ID ONLY is data from BAL