### PR TITLE
Increased payload express memory limit

### DIFF
--- a/lib/api/address/routes.js
+++ b/lib/api/address/routes.js
@@ -14,7 +14,6 @@ const BAN_API_URL
 const nanoid = customAlphabet('123456789ABCDEFGHJKMNPQRSTVWXYZ', 9)
 
 const app = new express.Router()
-app.use(express.json())
 
 app.get('/:addressID', async (req, res) => {
   let response

--- a/lib/api/ban-id/routes.js
+++ b/lib/api/ban-id/routes.js
@@ -3,7 +3,6 @@ import express from 'express'
 import {getUuids, uncollidUuids} from './helpers.js'
 
 const app = new express.Router()
-app.use(express.json())
 
 app.get('/', async (req, res) => {
   let response

--- a/lib/api/common-toponym/routes.js
+++ b/lib/api/common-toponym/routes.js
@@ -14,7 +14,6 @@ const BAN_API_URL
 const nanoid = customAlphabet('123456789ABCDEFGHJKMNPQRSTVWXYZ', 9)
 
 const app = new express.Router()
-app.use(express.json())
 
 app.get('/:commonToponymID', async (req, res) => {
   let response

--- a/lib/api/district/routes.js
+++ b/lib/api/district/routes.js
@@ -13,7 +13,6 @@ const BAN_API_URL
 const nanoid = customAlphabet('123456789ABCDEFGHJKMNPQRSTVWXYZ', 9)
 
 const app = new express.Router()
-app.use(express.json())
 
 app.get('/:districtID', async (req, res) => {
   let response

--- a/lib/api/job-status/routes.js
+++ b/lib/api/job-status/routes.js
@@ -5,7 +5,6 @@ import {getJobStatus} from '../job-status/models.js'
 const apiQueue = queue('api')
 
 const app = new express.Router()
-app.use(express.json())
 
 app.get('/:statusID', async (req, res) => {
   let response

--- a/lib/api/legacy-routes.cjs
+++ b/lib/api/legacy-routes.cjs
@@ -54,8 +54,6 @@ function ensureIsAdmin(req, res, next) {
 
 const app = new express.Router()
 
-app.use(express.json())
-
 app.param(
   'codeCommune',
   w(async (req, res, next) => {

--- a/server.js
+++ b/server.js
@@ -17,6 +17,8 @@ async function main() {
     app.use(morgan('dev'))
   }
 
+  app.use(express.json({limit: '20mb'}))
+
   app.use(cors({origin: true}))
 
   app.get('/ping', (req, res) => {


### PR DESCRIPTION
I. Context

When using ban-plateforme APIs, we are sending data to create addresses, toponyms, ... etc. Sometimes, the size of the data is higher than the default payload authorized by express (= 100kb).

II. Enhancement

This PR aims to increase the size of the express payload limit to 20mb (Toulouse BAL being the heaviest BAL and being around 9mb)