### PR TITLE
Modify job status db schema with migration file

### DIFF
--- a/db-migrations/migrations/20230822124246-add-columns-to-job-statuses.cjs
+++ b/db-migrations/migrations/20230822124246-add-columns-to-job-statuses.cjs
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('JobStatuses', 'dataType', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    })
+
+    await queryInterface.addColumn('JobStatuses', 'jobType', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    })
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('JobStatuses', 'dataType')
+    await queryInterface.removeColumn('JobStatuses', 'jobType')
+  },
+}

--- a/lib/util/sequelize.js
+++ b/lib/util/sequelize.js
@@ -124,6 +124,14 @@ export const JobStatus = sequelize.define('JobStatus', {
     type: DataTypes.STRING,
     allowNull: true,
   },
+  dataType: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  jobType: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
   count: {
     type: DataTypes.INTEGER,
     allowNull: true,


### PR DESCRIPTION
I. Enhancement : 

This PR aims to add "jobType" and "datType" data into the postgres DB table "JobStatuses" by : 

- Modifying the JobStatus sequelize schema
- Adding a migration file for the PostgreSQL DB

jobType possible values : 
- "insert"
- "update"
- "delete"

dataType possible values : 
- "address"
- "commonToponym"
- "district"

II. How to test : 

1- First, check the structure of your postgresql table "JobStatuses" => you should see that there are no columns "jobType" and "datType"
2- Then, start the migration command : 

`yarn migrate:up --name 20230822124246-add-columns-to-job-statuses.cjs`

3- Finally, check again the structure of your postgresql table "JobStatuses" => now, the two columns "jobType" and "datType" have been added.
4- You can also undo the migration by using the command : 

`yarn migrate:undo --name 20230822124246-add-columns-to-job-statuses.cjs`
