### PR TITLE
ajout du banId sur les résultats du lookup de voie et de commune

### DIFF
--- a/lib/models/commune.cjs
+++ b/lib/models/commune.cjs
@@ -141,6 +141,7 @@ async function getCommunesSummary() {
 async function getPopulatedCommune(codeCommune) {
   const communeFields = [
     'codeCommune',
+    'banId',
     'nomCommune',
     'departement',
     'region',
@@ -164,7 +165,7 @@ async function getPopulatedCommune(codeCommune) {
     return
   }
 
-  const voiesFields = ['type', 'idVoie', 'nomVoie', 'nomVoieAlt', 'sourceNomVoie', 'sources', 'nbNumeros', 'nbNumerosCertifies']
+  const voiesFields = ['type', 'idVoie', 'banId', 'nomVoie', 'nomVoieAlt', 'sourceNomVoie', 'sources', 'nbNumeros', 'nbNumerosCertifies']
 
   const voies = await mongo.db.collection('voies')
     .find({codeCommune}, {projection: fieldsToProj(voiesFields)})
@@ -179,7 +180,7 @@ async function getPopulatedCommune(codeCommune) {
 }
 
 async function getPopulatedVoie(idVoie) {
-  const voieFields = ['type', 'idVoie', 'nomVoie', 'nomVoieAlt', 'sourceNomVoie', 'sources', 'codeCommune', 'nbNumeros', 'nbNumerosCertifies', 'displayBBox', 'dateMAJ']
+  const voieFields = ['type', 'idVoie', 'banId', 'nomVoie', 'nomVoieAlt', 'sourceNomVoie', 'sources', 'codeCommune', 'nbNumeros', 'nbNumerosCertifies', 'displayBBox', 'dateMAJ']
 
   const voie = await mongo.db.collection('voies')
     .findOne({idVoie}, {projection: fieldsToProj(voieFields)})
@@ -189,10 +190,14 @@ async function getPopulatedVoie(idVoie) {
   }
 
   const commune = getCommuneCOG(voie.codeCommune)
+
+  const communeBAN = await mongo.db.collection('communes')
+    .findOne({codeCommune: voie.codeCommune})
+
   const communeFields = ['nom', 'code', 'departement', 'region']
 
-  const numeroLDFields = ['numero', 'suffixe', 'idVoie', 'parcelles', 'sources', 'position', 'positionType', 'sourcePosition', 'certifie', 'codePostal', 'libelleAcheminement', 'id', 'dateMAJ']
-  const numerosVoieFields = ['numero', 'suffixe', 'lieuDitComplementNom', 'lieuDitComplementNomAlt', 'parcelles', 'sources', 'position', 'positionType', 'sourcePosition', 'certifie', 'codePostal', 'libelleAcheminement', 'id', 'dateMAJ']
+  const numeroLDFields = ['numero', 'suffixe', 'idVoie', 'parcelles', 'sources', 'position', 'positionType', 'sourcePosition', 'certifie', 'codePostal', 'libelleAcheminement', 'id', 'banId', 'dateMAJ']
+  const numerosVoieFields = ['numero', 'suffixe', 'lieuDitComplementNom', 'lieuDitComplementNomAlt', 'parcelles', 'sources', 'position', 'positionType', 'sourcePosition', 'certifie', 'codePostal', 'libelleAcheminement', 'id', 'banId', 'dateMAJ']
 
   let numeros
   if (voie.type === 'voie') {
@@ -216,6 +221,7 @@ async function getPopulatedVoie(idVoie) {
     codeCommune: undefined,
     commune: {
       id: commune.code,
+      banId: communeBAN.banId,
       ...pick(commune, communeFields),
       departement: pick(getDepartement(commune.departement), 'nom', 'code'),
       region: pick(getRegion(commune.region), 'nom', 'code')


### PR DESCRIPTION
pourr les numéros c'était déjà bon.

On rajoute les information au lookup, elles pourront ensuite être exploitées dans l'explorateur de la BAN pour les afficher.
Les informations sont à null lorsque ce n'est pas rempli dans la BAN.

résultat : 
http://localhost:5001/lookup/60145

{
    "id": "60145",
    "type": "commune",
    "codeCommune": "60145",
    **"banId": "a6b986fb-b434-474d-a0cc-69abb7ac2b61",**
    "nomCommune": "Chelles",
    "departement": {
        "nom": "Oise",
        "code": "60"
    },
    ...
    "idRevision": "64c000b662c8b91a042713e7",
    "dateRevision": "2023-07-25T17:04:55.112Z",
    "voies": [
        {
            "id": "60145_0750",
            "type": "voie",
            **"banId": "a0a73acc-bcc3-405d-821f-0879221b887a",**
            "idVoie": "60145_0750",
            "nomVoie": "Rue de Bérogne",
            "nomVoieAlt": {},
            "sourceNomVoie": "bal",
            "sources": [
                "bal"
            ],
            "nbNumeros": 17,
            "nbNumerosCertifies": 17
        },

http://localhost:5001/lookup/60145_0750	
{
    "id": "60145_0750",
    "type": "voie",
    **"banId": "a0a73acc-bcc3-405d-821f-0879221b887a",**
    "idVoie": "60145_0750",
    "nomVoie": "Rue de Bérogne",
    "nomVoieAlt": {},
    "sourceNomVoie": "bal",
    "sources": [
        "bal"
    ],
  ...
    "nbNumeros": 17,
    "nbNumerosCertifies": 17,
    "commune": {
        "id": "60145",
        **"banId": "a6b986fb-b434-474d-a0cc-69abb7ac2b61",**
        "nom": "Chelles",
        "code": "60145",
        "departement": {
            "nom": "Oise",
            "code": "60"
        },
        "region": {
            "nom": "Hauts-de-France",
            "code": "32"
        }
    },
    "numeros": [
        {
            **"banId": "f34280b6-f446-43fa-adc4-aff091c9c476",**
            "numero": 1,
            "suffixe": null,
            "lieuDitComplementNom": null,
            "lieuDitComplementNomAlt": {},
            "parcelles": [
                "601450000A0610"
            ],
            "sources": [
                "bal"
            ],
            "dateMAJ": "2017-08-03",
            "certifie": true,
            "position": {
                "type": "Point",
                "coordinates": [
                    3.0414244,
                    49.3556188
                ]
            },
            "positionType": "entrée",
            "sourcePosition": "bal",
            "codePostal": "60350",
            "libelleAcheminement": "CHELLES",
            "id": "60145_0750_00001"
        },