### PR TITLE
ajout d'un test si le fantoir trouvé est annulé sans successeur

### DIFF
--- a/lib/compose/processors/recompute-codes-voies.cjs
+++ b/lib/compose/processors/recompute-codes-voies.cjs
@@ -34,6 +34,12 @@ async function recomputeCodesVoies(adressesCommune, fromBal) {
         // Avant d'attribuer le fantoir je vérifie que le couple libellé/fantoir n'apparait pas dans le set
         const libelle = adresse.nomVoie
         const idVoie = fantoir.successeur?.replace('-', '_') || fantoir.codeCommune + '_' + fantoir.codeFantoir
+        // Si le code fantoir correspond à une voie annulée sans successeur, on return les adresses dans code fantoir
+
+        if (!fantoir.successeur && fantoir.annulee) {
+          return {adresses}
+        }
+
         if (fromBal && listIdVoie.has(idVoie) && !listLibelleIdVoie.has(libelle + idVoie)) {
           return {adresses}
         }


### PR DESCRIPTION
deuxième PR liée à l'issue #151 (l'autre PR est sur fantoir).
Permet ici de ne plus renvoyer de code fantoir annulé.
Dans ce cas on préfère renvoyer un pseudo code.