### PR TITLE
Added labels field to address schema and its migration file

### DIFF
--- a/db-migrations/migrations/20230912161927-add-labels-to-addresses.cjs
+++ b/db-migrations/migrations/20230912161927-add-labels-to-addresses.cjs
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Addresses', 'labels', {
+      type: Sequelize.ARRAY(Sequelize.JSONB),
+      allowNull: true,
+    })
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Addresses', 'labels')
+  }
+}

--- a/lib/api/address/schema.js
+++ b/lib/api/address/schema.js
@@ -1,5 +1,5 @@
 import {object, string, number, boolean, array, date} from 'yup'
-import {banID, geometrySchema, cadastreSchema} from '../schema.js'
+import {banID, geometrySchema, labelSchema, cadastreSchema} from '../schema.js'
 
 const PositionTypes = ['entrance', 'building', 'staircase identifier', 'unit identifier', 'utility service', 'postal delivery', 'parcel', 'segment', 'other']
 
@@ -19,6 +19,7 @@ export const banAddressSchema = object({
   districtID: banID.required(),
   number: number().positive().integer().required(),
   suffix: string().trim(),
+  labels: array().of(labelSchema).default(null).nullable(),
   certified: boolean(),
   positions: array().of(positionSchema).required(),
   updateDate: date().required(),

--- a/lib/util/sequelize.js
+++ b/lib/util/sequelize.js
@@ -96,6 +96,10 @@ export const Address = sequelize.define('Address', {
     type: DataTypes.STRING,
     allowNull: true,
   },
+  labels: {
+    type: DataTypes.ARRAY(DataTypes.JSONB),
+    allowNull: true,
+  },
   certified: {
     type: DataTypes.BOOLEAN,
     allowNull: true,


### PR DESCRIPTION
I. Context : 
The field "lieudit_complement_nom" is currently not handled is the new BAN-ID data schema. We need to add it to the data schema and migrate the postgresql structure to add the column

II. Enhancements : 
This PR aims to add a new filed in the "address" schema : 

`labels: array().of(labelSchema).default(null).nullable()` <= The field is not required BUT if existing, it has to fit with the already existing `labelSchema` defined as followed : 

```
export const labelSchema = object({
  isoCode: string().trim().length(3).required(),
  value: string().trim().required(),
})
```

III. How to test

1- Use the migration file to modify your postgreSQL structure (adding a `labels` column into your Addresses table). Here is the following command to start : 

`npx sequelize-cli db:migrate --name 20230912161927-add-labels-to-addresses.cjs`

You should see : 

```
== 20230912161927-add-labels-to-addresses: migrating =======
== 20230912161927-add-labels-to-addresses: migrated (0.012s)
```

2- Download a BAL (csv) and make sure at least one of the address has a `lieudit_complement_nom`. If not, add it manually in the CSV and save it.
3- Use the `initBALIntoBAN` script on ID-Fix to push your BAL into the BAN. 
4- Go in the PostgreSQL DB, on Addresses table and look for the address(es) that has(have) the `lieudit_complement_nom`.
5- Verify that the "labels" column is filled with the correct data.

IV. Complementary information

1- When deploying on production, make sure to do the migration before starting the ban-api and ban-worker