### PR TITLE
Added postgis plugin into postgres docker image for local development 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     volumes:
       - db-mongo:/data/db
   db-postgres:
-    image: postgres:15-alpine
+    build: 
+      dockerfile: docker-resources/postgres/Dockerfile.dev
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     environment:

--- a/docker-resources/postgres/Dockerfile.dev
+++ b/docker-resources/postgres/Dockerfile.dev
@@ -1,0 +1,8 @@
+# Use the official PostgreSQL image as the base image
+FROM postgres:15
+
+# Install PostGIS extension
+RUN apt-get update && apt-get install -y postgresql-15-postgis-3
+
+# Copy a script to activate PostGIS
+COPY docker-resources/postgres/init-postgis.sh /docker-entrypoint-initdb.d

--- a/docker-resources/postgres/init-postgis.sh
+++ b/docker-resources/postgres/init-postgis.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+echo "Activating PostGIS extension..."
+psql -U $POSTGRES_USER -d $POSTGRES_DB -c "CREATE EXTENSION postgis;"


### PR DESCRIPTION
I. Context : 

In order to be able to calculate some enhanced data (such as common toponym centroids), we would like to use postgis plugin to the postgres DB. 

II. Enhancements : 

This PR aims to add the postgis plugin into the postgres docker image by adding : 
- a Dockerfile.dev for the postgres image to install the plugin into the image
- an init-postgis.sh to activate the plugin at the first initialization of the container