### PR TITLE
dissociate put and patch routes for new api

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,7 +4,7 @@ MONGODB_PORT=27017 # Used only for deployment with Docker Compose
 MONGODB_DBNAME=ban
 
 # Postgres DB
-POSTGRES_URL=http://127.0.0.1:5432 # Not used for deployment with Docker Compose
+POSTGRES_URL=localhost # Not used for deployment with Docker Compose
 POSTGRES_PORT=5432 # Used only for deployment with Docker Compose
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres

--- a/lib/api/address/__mocks__/address-data-mock.js
+++ b/lib/api/address/__mocks__/address-data-mock.js
@@ -47,6 +47,28 @@ export const addressMock = [
   }
 ]
 
+export const addressMockForPatch = [
+  {
+    id: '00000000-0000-4fff-9fff-00000000002a',
+    number: 11,
+  },
+  {
+    id: '00000000-0000-4fff-9fff-00000000002b',
+    positions: [{
+      type: 'entrance',
+      geometry: {
+        type: 'Point',
+        coordinates: [1.27, 2.34]
+      }
+    }]
+  },
+  {
+    id: '00000000-0000-4fff-9fff-00000000002c',
+    mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001b',
+    secondaryCommonToponymIDs: ['00000000-0000-4fff-9fff-00000000001c'],
+  }
+]
+
 export const bddAddressMock = [
   {
     id: '00000000-0000-4fff-9fff-00000000002a',

--- a/lib/api/address/routes.js
+++ b/lib/api/address/routes.js
@@ -71,6 +71,33 @@ app.route('/')
 
     res.send(response)
   })
+  .patch(auth, analyticsMiddleware, async (req, res) => {
+    let response
+    try {
+      const addresses = req.body
+      const statusID = nanoid()
+
+      await apiQueue.add(
+        {dataType: 'address', jobType: 'patch', data: addresses, statusID},
+        {jobId: statusID, removeOnComplete: true}
+      )
+      response = {
+        date: new Date(),
+        status: 'success',
+        message: `Check the status of your request : ${BAN_API_URL}/job-status/${statusID}`,
+        response: {statusID},
+      }
+    } catch (error) {
+      response = {
+        date: new Date(),
+        status: 'error',
+        message: error,
+        response: {},
+      }
+    }
+
+    res.send(response)
+  })
 
 app.route('/:addressID')
   .get(analyticsMiddleware, async (req, res) => {

--- a/lib/api/address/schema.js
+++ b/lib/api/address/schema.js
@@ -19,10 +19,32 @@ export const banAddressSchema = object({
   districtID: banID.required(),
   number: number().positive().integer().required(),
   suffix: string().trim(),
-  labels: array().of(labelSchema).default(null).nullable(),
+  labels: array().of(labelSchema),
   certified: boolean(),
   positions: array().of(positionSchema).required(),
   updateDate: date().required(),
   meta: metaSchema
 })
+
+export const banAddressSchemaForPatch = object({
+  id: banID.required(),
+  mainCommonToponymID: banID,
+  secondaryCommonToponymIDs: array().of(banID),
+  districtID: banID,
+  number: number().positive().integer(),
+  suffix: string().trim(),
+  labels: array().of(labelSchema).default(null).nullable(),
+  certified: boolean().default(false),
+  positions: array().of(positionSchema).default(null).nullable(),
+  updateDate: date(),
+  meta: metaSchema
+})
+
+export const addressDefaultOptionalValues = {
+  secondaryCommonToponymIDs: [],
+  suffix: '',
+  labels: [],
+  certified: false,
+  meta: undefined,
+}
 

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -1,7 +1,7 @@
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfCommonToponymsExist, checkIfDistrictsExist} from '../helper.js'
 import {banID} from '../schema.js'
 import {getAddresses, getAllAddressIDsFromDistrict, getAllAddressIDsOutsideDistrict} from './models.js'
-import {banAddressSchema} from './schema.js'
+import {banAddressSchema, banAddressSchemaForPatch} from './schema.js'
 
 const getExistingAddressIDs = async addressIDs => {
   const existingAddresses = await getAddresses(addressIDs)
@@ -24,6 +24,7 @@ export const checkAddressesIDsRequest = async (addressIDs, actionType, defaultRe
         )
         break
       case 'update':
+      case 'patch':
         report = (
           checkIdsIsUniq('Shared IDs in request', addressIDs)
           || await checkIdsIsAvailable('Some unknown IDs', addressIDs, getExistingAddressIDs)
@@ -65,6 +66,31 @@ export const checkAddressesRequest = async (addresses, actionType) => {
           return [...acc, ...ids]
         }, []))
         || await checkIfDistrictsExist(addresses.map(({districtID}) => districtID))
+        || dataValidationReportFrom(true)
+      break
+    case 'patch':
+      report = checkDataFormat(
+        `The request require an Array of address but receive ${typeof addresses}`,
+        'No address send to job',
+        addresses
+      )
+        || await checkAddressesIDsRequest(addresses.map(address => address.id), actionType, false)
+        || await checkDataShema('Invalid format', addresses, banAddressSchemaForPatch)
+        || await checkIfCommonToponymsExist(addresses.reduce((acc, {mainCommonToponymID, secondaryCommonToponymIDs}) => {
+          const ids = mainCommonToponymID ? [mainCommonToponymID] : []
+          if (secondaryCommonToponymIDs) {
+            ids.push(...secondaryCommonToponymIDs)
+          }
+
+          return [...acc, ...ids]
+        }, []))
+        || await checkIfDistrictsExist(addresses.reduce((acc, {districtID}) => {
+          if (districtID) {
+            return [...acc, districtID]
+          }
+
+          return acc
+        }, []))
         || dataValidationReportFrom(true)
       break
     default:

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -1,6 +1,6 @@
 import {jest} from '@jest/globals'
 import {object, string, bool, array} from 'yup'
-import {addressMock, bddAddressMock} from './__mocks__/address-data-mock.js'
+import {addressMock, addressMockForPatch, bddAddressMock} from './__mocks__/address-data-mock.js'
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/address-models.js'))
 jest.unstable_mockModule('../common-toponym/models.js', async () => import('../common-toponym/__mocks__/common-toponym-models.js'))
@@ -33,7 +33,7 @@ describe('checkAddressesIDsRequest', () => {
     expect(addressesValidation?.report?.data).toEqual([sharedID])
   })
 
-  it('All unkown IDs', async () => {
+  it('All unkown IDs on delete', async () => {
     const addressesValidation = await checkAddressesIDsRequest(addressMock.map(({id}) => id), 'delete')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -42,7 +42,7 @@ describe('checkAddressesIDsRequest', () => {
     addressMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Some unkown IDs', async () => {
+  it('Some unkown IDs on delete', async () => {
     const addressesValidation = await checkAddressesIDsRequest([...addressMock, ...bddAddressMock].map(({id}) => id), 'delete')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -53,7 +53,7 @@ describe('checkAddressesIDsRequest', () => {
 })
 
 describe('checkAddressesRequest', () => {
-  it('Shared IDs', async () => {
+  it('Shared IDs on insert', async () => {
     const sharedID = '00000000-0000-4fff-9fff-aaaaaaaaaaaa'
     const addressesValidation = await checkAddressesRequest(addressMock.map(addr => ({...addr, id: sharedID})), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
@@ -62,7 +62,7 @@ describe('checkAddressesRequest', () => {
     expect(addressesValidation?.report?.data).toEqual([sharedID])
   })
 
-  it('All unavailable IDs', async () => {
+  it('All unavailable IDs on insert', async () => {
     const addressesValidation = await checkAddressesRequest(bddAddressMock.map(({_id, ...addr}) => addr), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -71,7 +71,7 @@ describe('checkAddressesRequest', () => {
     bddAddressMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Some unavailable IDs', async () => {
+  it('Some unavailable IDs on insert', async () => {
     const addressesValidation = await checkAddressesRequest([...addressMock, ...bddAddressMock].map(({_id, ...addr}) => addr), 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -80,14 +80,30 @@ describe('checkAddressesRequest', () => {
     bddAddressMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Available addresses and IDs on Insert', async () => {
+  it('Some unavailable common toponym IDs on insert', async () => {
+    const addressesValidation = await checkAddressesRequest(addressMock.map(addr => ({...addr, mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001d'})), 'insert')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    expect(addressesValidation?.report?.data).toEqual(['00000000-0000-4fff-9fff-00000000001d'])
+  })
+
+  it('Some unavailable district IDs on insert', async () => {
+    const addressesValidation = await checkAddressesRequest(addressMock.map(addr => ({...addr, districtID: '00000000-0000-4fff-9fff-000000000003'})), 'insert')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    expect(addressesValidation?.report?.data).toEqual(['00000000-0000-4fff-9fff-000000000003'])
+  })
+
+  it('Available addresses and IDs on insert', async () => {
     const addressesValidation = await checkAddressesRequest(addressMock, 'insert')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)
   })
 
-  it('Unknown IDs on Update', async () => {
+  it('Unknown IDs on update', async () => {
     const addressesValidation = await checkAddressesRequest(addressMock, 'update')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -95,8 +111,55 @@ describe('checkAddressesRequest', () => {
     addressMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Available addresses on Update', async () => {
+  it('Some unavailable common toponym IDs on update', async () => {
+    const addressesValidation = await checkAddressesRequest(bddAddressMock.map(addr => ({...addr, mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001d'})), 'update')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    expect(addressesValidation?.report?.data).toEqual(['00000000-0000-4fff-9fff-00000000001d'])
+  })
+
+  it('Some unavailable district IDs on update', async () => {
+    const addressesValidation = await checkAddressesRequest(bddAddressMock.map(addr => ({...addr, districtID: '00000000-0000-4fff-9fff-000000000003'})), 'update')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    expect(addressesValidation?.report?.data).toEqual(['00000000-0000-4fff-9fff-000000000003'])
+  })
+
+  it('Available addresses on update', async () => {
     const addressesValidation = await checkAddressesRequest(bddAddressMock.map(addr => ({...addr, certifie: true})), 'update')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(true)
+  })
+
+  it('Unknown IDs on patch', async () => {
+    const addressesValidation = await checkAddressesRequest(addressMock, 'patch')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    addressMock.forEach(({id}) => expect(addressesValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Some unavailable common toponym IDs on patch', async () => {
+    const addressesValidation = await checkAddressesRequest(addressMockForPatch.map(addr => ({...addr, mainCommonToponymID: '00000000-0000-4fff-9fff-00000000001d'})), 'patch')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    expect(addressesValidation?.report?.data).toEqual(['00000000-0000-4fff-9fff-00000000001d'])
+  })
+
+  it('Some unavailable district IDs on patch', async () => {
+    const addressesValidation = await checkAddressesRequest(addressMockForPatch.map(addr => ({...addr, districtID: '00000000-0000-4fff-9fff-000000000003'})), 'patch')
+    const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(addressesValidation?.isValid).toBe(false)
+    expect(addressesValidation?.report?.data).toEqual(['00000000-0000-4fff-9fff-000000000003'])
+  })
+
+  it('Available addresses on patch', async () => {
+    const addressesValidation = await checkAddressesRequest(addressMockForPatch, 'patch')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)

--- a/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
+++ b/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
@@ -27,6 +27,28 @@ export const commonToponymMock = [
   }
 ]
 
+export const commonToponymMockForPatch = [
+  {
+    id: '00000000-0000-4fff-9fff-00000000001a',
+    labels: [{
+      isoCode: 'fra',
+      value: 'Rue du Lapin'
+    }]
+  },
+  {
+    id: '00000000-0000-4fff-9fff-00000000001b',
+    districtID: '00000000-0000-4fff-9fff-000000000001',
+  },
+  {
+    id: '00000000-0000-4fff-9fff-00000000001c',
+    geometry: {
+      type: 'Point',
+      coordinates: [1.2346, 2.3456]
+    },
+    updateDate: '2023-04-24'
+  }
+]
+
 export const bddCommonToponymMock = [
   {
     id: '00000000-0000-4fff-9fff-00000000001a',

--- a/lib/api/common-toponym/routes.js
+++ b/lib/api/common-toponym/routes.js
@@ -71,6 +71,33 @@ app.route('/')
 
     res.send(response)
   })
+  .patch(auth, analyticsMiddleware, async (req, res) => {
+    let response
+    try {
+      const commonToponyms = req.body
+      const statusID = nanoid()
+
+      await apiQueue.add(
+        {dataType: 'commonToponym', jobType: 'patch', data: commonToponyms, statusID},
+        {jobId: statusID, removeOnComplete: true}
+      )
+      response = {
+        date: new Date(),
+        status: 'success',
+        message: `Check the status of your request : ${BAN_API_URL}/job-status/${statusID}`,
+        response: {statusID},
+      }
+    } catch (error) {
+      response = {
+        date: new Date(),
+        status: 'error',
+        message: error,
+        response: {},
+      }
+    }
+
+    res.send(response)
+  })
 
 app.route('/:commonToponymID')
   .get(analyticsMiddleware, async (req, res) => {

--- a/lib/api/common-toponym/schema.js
+++ b/lib/api/common-toponym/schema.js
@@ -13,3 +13,17 @@ export const banCommonToponymSchema = object({
   updateDate: date().required(),
   meta: metaSchema
 })
+
+export const banCommonToponymSchemaForPatch = object({
+  id: banID.required(),
+  districtID: banID,
+  labels: array().of(labelSchema).default(null).nullable(),
+  geometry: geometrySchema.default(null).nullable(),
+  updateDate: date(),
+  meta: metaSchema
+})
+
+export const commonToponymDefaultOptionalValues = {
+  geometry: undefined,
+  meta: undefined,
+}

--- a/lib/api/common-toponym/utils.js
+++ b/lib/api/common-toponym/utils.js
@@ -1,7 +1,7 @@
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfDistrictsExist} from '../helper.js'
 import {banID} from '../schema.js'
 import {getCommonToponyms, getAllCommonToponymIDsFromDistrict, getAllCommonToponymIDsOutsideDistrict} from './models.js'
-import {banCommonToponymSchema} from './schema.js'
+import {banCommonToponymSchema, banCommonToponymSchemaForPatch} from './schema.js'
 
 const getExistingCommonToponymIDs = async commonToponymIDs => {
   const existingCommonToponyms = await getCommonToponyms(commonToponymIDs)
@@ -24,6 +24,7 @@ export const checkCommonToponymsIDsRequest = async (commonToponymIDs, actionType
         )
         break
       case 'update':
+      case 'patch':
         report = (
           checkIdsIsUniq('Shared IDs in request', commonToponymIDs)
           || await checkIdsIsAvailable('Some unknown IDs', commonToponymIDs, getExistingCommonToponymIDs)
@@ -57,6 +58,23 @@ export const checkCommonToponymsRequest = async (commonToponyms, actionType) => 
         || await checkCommonToponymsIDsRequest(commonToponyms.map(commonToponym => commonToponym.id), actionType, false)
         || await checkDataShema('Invalid common toponym format', commonToponyms, banCommonToponymSchema)
         || await checkIfDistrictsExist(commonToponyms.map(({districtID}) => districtID))
+        || dataValidationReportFrom(true)
+      break
+    case 'patch':
+      report = checkDataFormat(
+        `The request require an Array of common toponym but receive ${typeof commonToponyms}`,
+        'No common toponym send to job',
+        commonToponyms
+      )
+        || await checkCommonToponymsIDsRequest(commonToponyms.map(commonToponym => commonToponym.id), actionType, false)
+        || await checkDataShema('Invalid common toponym format', commonToponyms, banCommonToponymSchemaForPatch)
+        || await checkIfDistrictsExist(commonToponyms.reduce((acc, {districtID}) => {
+          if (districtID) {
+            return [...acc, districtID]
+          }
+
+          return acc
+        }, []))
         || dataValidationReportFrom(true)
       break
     default:

--- a/lib/api/common-toponym/utils.spec.js
+++ b/lib/api/common-toponym/utils.spec.js
@@ -1,6 +1,6 @@
 import {jest} from '@jest/globals'
 import {object, string, bool, array} from 'yup'
-import {commonToponymMock, bddCommonToponymMock} from './__mocks__/common-toponym-data-mock.js'
+import {commonToponymMock, commonToponymMockForPatch, bddCommonToponymMock} from './__mocks__/common-toponym-data-mock.js'
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/common-toponym-models.js'))
 jest.unstable_mockModule('../district/models.js', async () => import('../district/__mocks__/district-models.js'))
@@ -32,7 +32,7 @@ describe('checkCommonToponymsIDsRequest', () => {
     expect(commonToponymsValidation?.report?.data).toEqual([sharedID])
   })
 
-  it('All unkown IDs', async () => {
+  it('All unkown IDs on delete', async () => {
     const commonToponymsValidation = await checkCommonToponymsIDsRequest(commonToponymMock.map(({id}) => id), 'delete')
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -41,7 +41,7 @@ describe('checkCommonToponymsIDsRequest', () => {
     commonToponymMock.forEach(({id}) => expect(commonToponymsValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Some unkown IDs', async () => {
+  it('Some unkown IDs on delete', async () => {
     const commonToponymsValidation = await checkCommonToponymsIDsRequest([...commonToponymMock, ...bddCommonToponymMock].map(({id}) => id), 'delete')
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -52,7 +52,7 @@ describe('checkCommonToponymsIDsRequest', () => {
 })
 
 describe('checkCommonToponymsRequest', () => {
-  it('Shared IDs', async () => {
+  it('Shared IDs on insert', async () => {
     const sharedID = '00000000-0000-4fff-9fff-aaaaaaaaaaaa'
     const commonToponymsValidation = await checkCommonToponymsRequest(commonToponymMock.map(commonToponym => ({...commonToponym, id: sharedID})), 'insert')
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
@@ -61,7 +61,7 @@ describe('checkCommonToponymsRequest', () => {
     expect(commonToponymsValidation?.report?.data).toEqual([sharedID])
   })
 
-  it('All unavailable IDs', async () => {
+  it('All unavailable IDs on insert', async () => {
     const commonToponymsValidation = await checkCommonToponymsRequest(bddCommonToponymMock.map(({_id, ...commonToponym}) => commonToponym), 'insert')
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -70,7 +70,7 @@ describe('checkCommonToponymsRequest', () => {
     bddCommonToponymMock.forEach(({id}) => expect(commonToponymsValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Some unavailable IDs', async () => {
+  it('Some unavailable IDs on insert', async () => {
     const commonToponymsValidation = await checkCommonToponymsRequest([...commonToponymMock, ...bddCommonToponymMock].map(({_id, ...commonToponym}) => commonToponym), 'insert')
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -79,14 +79,22 @@ describe('checkCommonToponymsRequest', () => {
     bddCommonToponymMock.forEach(({id}) => expect(commonToponymsValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Available commonToponyms and IDs on Insert', async () => {
+  it('Some unavailable district IDs on insert', async () => {
+    const commonToponymsValidation = await checkCommonToponymsRequest(commonToponymMock.map(commonToponym => ({...commonToponym, districtID: '00000000-0000-4fff-9fff-000000000003'})), 'insert')
+    const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(commonToponymsValidation?.isValid).toBe(false)
+    expect(commonToponymsValidation?.report?.data).toEqual(['00000000-0000-4fff-9fff-000000000003'])
+  })
+
+  it('Available commonToponyms and IDs on insert', async () => {
     const commonToponymsValidation = await checkCommonToponymsRequest(commonToponymMock, 'insert')
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(commonToponymsValidation?.isValid).toBe(true)
   })
 
-  it('Unknown IDs on Update', async () => {
+  it('Unknown IDs on update', async () => {
     const commonToponymsValidation = await checkCommonToponymsRequest(commonToponymMock, 'update')
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -94,8 +102,39 @@ describe('checkCommonToponymsRequest', () => {
     commonToponymMock.forEach(({id}) => expect(commonToponymsValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Available commonToponyms on Update', async () => {
+  it('Some unavailable district IDs on update', async () => {
+    const commonToponymsValidation = await checkCommonToponymsRequest(bddCommonToponymMock.map(commonToponym => ({...commonToponym, districtID: '00000000-0000-4fff-9fff-000000000003'})), 'update')
+    const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(commonToponymsValidation?.isValid).toBe(false)
+    expect(commonToponymsValidation?.report?.data).toEqual(['00000000-0000-4fff-9fff-000000000003'])
+  })
+
+  it('Available commonToponyms on update', async () => {
     const commonToponymsValidation = await checkCommonToponymsRequest(bddCommonToponymMock.map(commonToponym => ({...commonToponym, label: [{isoCode: 'fra', value: 'Rue de la mouette'}]})), 'update')
+    const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(commonToponymsValidation?.isValid).toBe(true)
+  })
+
+  it('Unknown IDs on patch', async () => {
+    const commonToponymsValidation = await checkCommonToponymsRequest(commonToponymMock, 'patch')
+    const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(commonToponymsValidation?.isValid).toBe(false)
+    commonToponymMock.forEach(({id}) => expect(commonToponymsValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Some unavailable district IDs on patch', async () => {
+    const commonToponymsValidation = await checkCommonToponymsRequest(commonToponymMockForPatch.map(addr => ({...addr, districtID: '00000000-0000-4fff-9fff-000000000003'})), 'patch')
+    const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(commonToponymsValidation?.isValid).toBe(false)
+    expect(commonToponymsValidation?.report?.data).toEqual(['00000000-0000-4fff-9fff-000000000003'])
+  })
+
+  it('Available addresses on patch', async () => {
+    const commonToponymsValidation = await checkCommonToponymsRequest(commonToponymMockForPatch, 'patch')
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(commonToponymsValidation?.isValid).toBe(true)

--- a/lib/api/consumers/api-consumer.js
+++ b/lib/api/consumers/api-consumer.js
@@ -6,7 +6,10 @@ import {setCommonToponyms, updateCommonToponyms, deleteCommonToponyms, getAllDis
 import {checkCommonToponymsRequest, checkCommonToponymsIDsRequest} from '../common-toponym/utils.js'
 import {setDistricts, updateDistricts, deleteDistricts} from '../district/models.js'
 import {checkDistrictsRequest, checkDistrictsIDsRequest} from '../district/utils.js'
-import {dataValidationReportFrom, addOrUpdateJob} from '../helper.js'
+import {dataValidationReportFrom, formatObjectWithDefaults, addOrUpdateJob} from '../helper.js'
+import {addressDefaultOptionalValues} from '../address/schema.js'
+import {commonToponymDefaultOptionalValues} from '../common-toponym/schema.js'
+import {districtDefaultOptionalValues} from '../district/schema.js'
 
 const exportToExploitationDBQueue = queue('export-to-exploitation-db')
 const exportToExploitationDBJobDelay = process.env.EXPORT_TO_EXPLOITATION_DB_JOB_DELAY || 10_000
@@ -60,6 +63,7 @@ const addressConsumer = async (jobType, payload, statusID) => {
     switch (jobType) {
       case 'insert':
       case 'update':
+      case 'patch':
         return checkAddressesRequest(payload, jobType)
       case 'delete':
         return checkAddressesIDsRequest(payload, jobType)
@@ -72,10 +76,23 @@ const addressConsumer = async (jobType, payload, statusID) => {
   const addressesCount = payload.length
   if (requestDataValidationReport.isValid) {
     switch (jobType) {
-      case 'insert':
-        await setAddresses(payload)
+      case 'insert': {
+        const formattedAddresses = payload.map(address => (
+          formatObjectWithDefaults(address, addressDefaultOptionalValues)
+        ))
+        await setAddresses(formattedAddresses)
         break
-      case 'update':
+      }
+
+      case 'update': {
+        const formattedAddresses = payload.map(address => (
+          formatObjectWithDefaults(address, addressDefaultOptionalValues)
+        ))
+        await updateAddresses(formattedAddresses)
+        break
+      }
+
+      case 'patch':
         await updateAddresses(payload)
         break
       case 'delete':
@@ -108,6 +125,7 @@ const commonToponymConsumer = async (jobType, payload, statusID) => {
     switch (jobType) {
       case 'insert':
       case 'update':
+      case 'patch':
         return checkCommonToponymsRequest(payload, jobType)
       case 'delete':
         return checkCommonToponymsIDsRequest(payload, jobType)
@@ -120,10 +138,23 @@ const commonToponymConsumer = async (jobType, payload, statusID) => {
   const commonToponymsCount = payload.length
   if (requestDataValidationReport.isValid) {
     switch (jobType) {
-      case 'insert':
-        await setCommonToponyms(payload)
+      case 'insert': {
+        const formattedCommonToponyms = payload.map(commonToponym => (
+          formatObjectWithDefaults(commonToponym, commonToponymDefaultOptionalValues)
+        ))
+        await setCommonToponyms(formattedCommonToponyms)
         break
-      case 'update':
+      }
+
+      case 'update': {
+        const formattedCommonToponyms = payload.map(commonToponym => (
+          formatObjectWithDefaults(commonToponym, commonToponymDefaultOptionalValues)
+        ))
+        await updateCommonToponyms(formattedCommonToponyms)
+        break
+      }
+
+      case 'patch':
         await updateCommonToponyms(payload)
         break
       case 'delete':
@@ -156,6 +187,7 @@ const districtConsumer = async (jobType, payload, statusID) => {
     switch (jobType) {
       case 'insert':
       case 'update':
+      case 'patch':
         return checkDistrictsRequest(payload, jobType)
       case 'delete':
         return checkDistrictsIDsRequest(payload, jobType)
@@ -168,10 +200,23 @@ const districtConsumer = async (jobType, payload, statusID) => {
   const districtsCount = payload.length
   if (requestDataValidationReport.isValid) {
     switch (jobType) {
-      case 'insert':
-        await setDistricts(payload)
+      case 'insert': {
+        const formattedDistricts = payload.map(district => (
+          formatObjectWithDefaults(district, districtDefaultOptionalValues)
+        ))
+        await setDistricts(formattedDistricts)
         break
-      case 'update':
+      }
+
+      case 'update': {
+        const formattedDistricts = payload.map(district => (
+          formatObjectWithDefaults(district, districtDefaultOptionalValues)
+        ))
+        await updateDistricts(formattedDistricts)
+        break
+      }
+
+      case 'patch':
         await updateDistricts(payload)
         break
       case 'delete':
@@ -205,6 +250,7 @@ export const extractRelatedDistrictIDs = async (dataType, jobType, payload) => {
       switch (jobType) {
         case 'insert':
         case 'update':
+        case 'patch':
           return getAllDistrictIDsFromAddresses(payload.map(({id}) => id))
         case 'delete':
           return getAllDistrictIDsFromAddresses(payload)
@@ -217,6 +263,7 @@ export const extractRelatedDistrictIDs = async (dataType, jobType, payload) => {
       switch (jobType) {
         case 'insert':
         case 'update':
+        case 'patch':
           return getAllDistrictIDsFromCommonToponyms(payload.map(({id}) => id))
         case 'delete':
           return getAllDistrictIDsFromCommonToponyms(payload)
@@ -229,6 +276,7 @@ export const extractRelatedDistrictIDs = async (dataType, jobType, payload) => {
       switch (jobType) {
         case 'insert':
         case 'update':
+        case 'patch':
           return payload.map(({id}) => id)
         case 'delete':
           return payload

--- a/lib/api/district/__mocks__/district-data-mock.js
+++ b/lib/api/district/__mocks__/district-data-mock.js
@@ -27,6 +27,28 @@ export const districtMock = [
   },
 ]
 
+export const districtMockForPatch = [
+  {
+    id: '00000000-0000-4fff-9fff-000000000000',
+    labels: [{
+      isoCode: 'fra',
+      value: 'Commune F'
+    }]
+  },
+  {
+    id: '00000000-0000-4fff-9fff-000000000001',
+    updateDate: '2023-06-23',
+  },
+  {
+    id: '00000000-0000-4fff-9fff-000000000002',
+    meta: {
+      insee: {
+        cog: '54324'
+      }
+    }
+  }
+]
+
 export const bddDistrictMock = [
   {
     id: '00000000-0000-4fff-9fff-000000000000',

--- a/lib/api/district/routes.js
+++ b/lib/api/district/routes.js
@@ -70,6 +70,33 @@ app.route('/')
 
     res.send(response)
   })
+  .patch(auth, analyticsMiddleware, async (req, res) => {
+    let response
+    try {
+      const districts = req.body
+      const statusID = nanoid()
+
+      await apiQueue.add(
+        {dataType: 'district', jobType: 'patch', data: districts, statusID},
+        {jobId: statusID, removeOnComplete: true}
+      )
+      response = {
+        date: new Date(),
+        status: 'success',
+        message: `Check the status of your request : ${BAN_API_URL}/job-status/${statusID}`,
+        response: {statusID},
+      }
+    } catch (error) {
+      response = {
+        date: new Date(),
+        status: 'error',
+        message: error,
+        response: {},
+      }
+    }
+
+    res.send(response)
+  })
 
 app.route('/:districtID')
   .get(analyticsMiddleware, async (req, res) => {

--- a/lib/api/district/schema.js
+++ b/lib/api/district/schema.js
@@ -16,3 +16,15 @@ export const banDistrictSchema = object({
   config: configSchema,
   meta: metaSchema
 })
+
+export const banDistrictSchemaForPatch = object({
+  id: banID.required(),
+  labels: array().of(labelSchema).default(null).nullable(),
+  updateDate: date(),
+  config: configSchema,
+  meta: metaSchema
+})
+
+export const districtDefaultOptionalValues = {
+  config: undefined,
+}

--- a/lib/api/district/schema.js
+++ b/lib/api/district/schema.js
@@ -22,7 +22,7 @@ export const banDistrictSchemaForPatch = object({
   labels: array().of(labelSchema).default(null).nullable(),
   updateDate: date(),
   config: configSchema,
-  meta: metaSchema
+  meta: metaSchema.default(null).nullable(),
 })
 
 export const districtDefaultOptionalValues = {

--- a/lib/api/district/utils.js
+++ b/lib/api/district/utils.js
@@ -1,7 +1,7 @@
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema} from '../helper.js'
 import {banID} from '../schema.js'
 import {getDistricts} from './models.js'
-import {banDistrictSchema} from './schema.js'
+import {banDistrictSchema, banDistrictSchemaForPatch} from './schema.js'
 
 const getExistingDistrictIDs = async districtIDs => {
   const existingDistricts = await getDistricts(districtIDs)
@@ -24,6 +24,7 @@ export const checkDistrictsIDsRequest = async (districtIDs, actionType, defaultR
         )
         break
       case 'update':
+      case 'patch':
         report = (
           checkIdsIsUniq('Shared IDs in request', districtIDs)
           || await checkIdsIsAvailable('Some unknown IDs', districtIDs, getExistingDistrictIDs)
@@ -49,13 +50,14 @@ export const checkDistrictsRequest = async (districts, actionType) => {
   switch (actionType) {
     case 'insert':
     case 'update':
+    case 'patch':
       report = checkDataFormat(
         `The request require an Array of district but receive ${typeof districts}`,
         'No district send to job',
         districts
       )
         || await checkDistrictsIDsRequest(districts.map(district => district.id), actionType, false)
-        || await checkDataShema('Invalid format', districts, banDistrictSchema)
+        || await checkDataShema('Invalid format', districts, actionType === 'patch' ? banDistrictSchemaForPatch : banDistrictSchema)
         || dataValidationReportFrom(true)
       break
     default:

--- a/lib/api/district/utils.spec.js
+++ b/lib/api/district/utils.spec.js
@@ -1,6 +1,6 @@
 import {jest} from '@jest/globals'
 import {object, string, bool, array} from 'yup'
-import {districtMock, bddDistrictMock} from './__mocks__/district-data-mock.js'
+import {districtMock, districtMockForPatch, bddDistrictMock} from './__mocks__/district-data-mock.js'
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/district-models.js'))
 const {checkDistrictsIDsRequest, checkDistrictsRequest} = await import('./utils.js')
@@ -31,7 +31,7 @@ describe('checkDistrictsIDsRequest', () => {
     expect(districtsValidation?.report?.data).toEqual([sharedID])
   })
 
-  it('All unkown IDs', async () => {
+  it('All unkown IDs on delete', async () => {
     const districtsValidation = await checkDistrictsIDsRequest(districtMock.map(({id}) => id), 'delete')
     const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -40,7 +40,7 @@ describe('checkDistrictsIDsRequest', () => {
     districtMock.forEach(({id}) => expect(districtsValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Some unkown IDs', async () => {
+  it('Some unkown IDs on delete', async () => {
     const districtsValidation = await checkDistrictsIDsRequest([...districtMock, ...bddDistrictMock].map(({id}) => id), 'delete')
     const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -51,7 +51,7 @@ describe('checkDistrictsIDsRequest', () => {
 })
 
 describe('checkDistrictsRequest', () => {
-  it('Shared IDs', async () => {
+  it('Shared IDs on insert', async () => {
     const sharedID = '00000000-0000-4fff-9fff-aaaaaaaaaaaa'
     const districtsValidation = await checkDistrictsRequest(districtMock.map(district => ({...district, id: sharedID})), 'insert')
     const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
@@ -60,7 +60,7 @@ describe('checkDistrictsRequest', () => {
     expect(districtsValidation?.report?.data).toEqual([sharedID])
   })
 
-  it('All unavailable IDs', async () => {
+  it('All unavailable IDs on insert', async () => {
     const districtsValidation = await checkDistrictsRequest(bddDistrictMock.map(({_id, ...district}) => district), 'insert')
     const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -69,7 +69,7 @@ describe('checkDistrictsRequest', () => {
     bddDistrictMock.forEach(({id}) => expect(districtsValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Some unavailable IDs', async () => {
+  it('Some unavailable IDs on insert', async () => {
     const districtsValidation = await checkDistrictsRequest([...districtMock, ...bddDistrictMock].map(({_id, ...district}) => district), 'insert')
     const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -78,14 +78,14 @@ describe('checkDistrictsRequest', () => {
     bddDistrictMock.forEach(({id}) => expect(districtsValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Available districts and IDs on Insert', async () => {
+  it('Available districts on insert', async () => {
     const districtsValidation = await checkDistrictsRequest(districtMock, 'insert')
     const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(districtsValidation?.isValid).toBe(true)
   })
 
-  it('Unknown IDs on Update', async () => {
+  it('Unknown IDs on update', async () => {
     const districtsValidation = await checkDistrictsRequest(districtMock, 'update')
     const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
     expect(testSchema).toBe(true)
@@ -93,8 +93,23 @@ describe('checkDistrictsRequest', () => {
     districtMock.forEach(({id}) => expect(districtsValidation?.report.data.includes(id)).toBe(true))
   })
 
-  it('Available districts on Update', async () => {
+  it('Available districts on update', async () => {
     const districtsValidation = await checkDistrictsRequest(bddDistrictMock.map(district => ({...district, label: [{isoCode: 'fra', value: 'commune F'}]})), 'update')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(true)
+  })
+
+  it('Unknown IDs on patch', async () => {
+    const districtsValidation = await checkDistrictsRequest(districtMock, 'patch')
+    const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
+    expect(testSchema).toBe(true)
+    expect(districtsValidation?.isValid).toBe(false)
+    districtMock.forEach(({id}) => expect(districtsValidation?.report.data.includes(id)).toBe(true))
+  })
+
+  it('Available districts on patch', async () => {
+    const districtsValidation = await checkDistrictsRequest(districtMockForPatch, 'patch')
     const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(districtsValidation?.isValid).toBe(true)

--- a/lib/api/helper.js
+++ b/lib/api/helper.js
@@ -77,7 +77,7 @@ export const checkIdsShema = async (err = 'Invalid IDs format', ids, schema) => 
 
 const dataSchemaValidation = async (data, schema) => {
   try {
-    await schema.validate(data, {abortEarly: false})
+    await schema.validate(data, {abortEarly: false, stripUnknown: true})
   } catch (error) {
     return dataValidationReportFrom(false, `Invalid data format (id: ${data.id})`, error.errors)
   }
@@ -131,4 +131,17 @@ export const addOrUpdateJob = async (queue, jobId, data, delay) => {
   } catch (error) {
     console.error(error)
   }
+}
+
+export const formatObjectWithDefaults = (inputObject, defaultValues) => {
+  const formattedObject = {...inputObject}
+  for (const key in defaultValues) {
+    // Check if the key is missing in the inputObject
+    if (!(key in formattedObject)) {
+      // If the key is missing, add it with the default value
+      formattedObject[key] = defaultValues[key]
+    }
+  }
+
+  return formattedObject
 }


### PR DESCRIPTION
I. Context

We need to be able to partially update an address, a common toponym or a district.

II. Enhancement

This PR aims to add 3 routes to partially updates the different entities : 
- PATCH /api/address/ (ONLY `id` is required)
- PATCH /api/common-toponym (ONLY `id` is required)
- PATCH /api/district (ONLY `id` is required)

III. How to test

1- On an existing address, use the PATCH /api/address to ONLY update some fields. Example : 

```
PATCH /api/address
[{
   id: 000018a1-25ff-46e1-81db-5c0b9e59345e,
   number: 4
}]

```