### PR TITLE
Added bal schema to address, common toponym and district meta schemas

### DIFF
--- a/lib/api/address/schema.js
+++ b/lib/api/address/schema.js
@@ -1,5 +1,5 @@
 import {object, string, number, boolean, array, date} from 'yup'
-import {banID, geometrySchema, labelSchema, cadastreSchema} from '../schema.js'
+import {banID, geometrySchema, labelSchema, cadastreSchema, balSchema} from '../schema.js'
 
 const PositionTypes = ['entrance', 'building', 'staircase identifier', 'unit identifier', 'utility service', 'postal delivery', 'parcel', 'segment', 'other']
 
@@ -9,7 +9,8 @@ const positionSchema = object({
 })
 
 const metaSchema = object({
-  cadastre: cadastreSchema
+  cadastre: cadastreSchema,
+  bal: balSchema,
 })
 
 export const banAddressSchema = object({

--- a/lib/api/common-toponym/schema.js
+++ b/lib/api/common-toponym/schema.js
@@ -1,8 +1,9 @@
 import {object, array, date} from 'yup'
-import {banID, geometrySchema, labelSchema, cadastreSchema} from '../schema.js'
+import {banID, geometrySchema, labelSchema, cadastreSchema, balSchema} from '../schema.js'
 
 const metaSchema = object({
-  cadastre: cadastreSchema
+  cadastre: cadastreSchema,
+  bal: balSchema,
 })
 
 export const banCommonToponymSchema = object({

--- a/lib/api/district/schema.js
+++ b/lib/api/district/schema.js
@@ -1,12 +1,13 @@
 import {object, array, date, bool} from 'yup'
-import {banID, labelSchema, inseeSchema} from '../schema.js'
+import {banID, labelSchema, inseeSchema, balSchema} from '../schema.js'
 
 const configSchema = object({
   useBanId: bool()
 })
 
 const metaSchema = object({
-  insee: inseeSchema
+  insee: inseeSchema,
+  bal: balSchema,
 })
 
 export const banDistrictSchema = object({

--- a/lib/api/schema.js
+++ b/lib/api/schema.js
@@ -1,4 +1,4 @@
-import {object, string, number, array} from 'yup'
+import {object, string, number, array, date, boolean} from 'yup'
 
 export const banID = string().trim().uuid()
 
@@ -19,3 +19,12 @@ export const inseeSchema = object({
 export const cadastreSchema = object({
   ids: array().of(string().trim())
 })
+
+export const balSchema = object({
+  idRevision: string().trim(),
+  dateRevision: date(),
+  codeAncienneCommune: string().trim(),
+  nomAncienneCommune: string().trim(),
+  isLieuDit: boolean()
+})
+


### PR DESCRIPTION
I. Context

In order to complete our new data schema with the BAL data, we need to store some extra information.

II. Enhancements

This PR aims to add in the new address, common toponym and district schemas the "bal" meta schema (optional field) that will store the following data : 
- idRevision <= data from "API de dépôt"
- dateRevision <= data from "API de dépôt"
- codeAncienneCommune <= field `commune_deleguee_insee` in BAL format,
- nomAncienneCommune  <= field `commune_deleguee_nom` in BAL format,
- isLieuDit <= if number === 99999

III. How to test

1- Post an an address, a common toponym or a district with the following meta : 

"meta": {
    "bal":{
      "idRevision":"ID_TEST",
      "dateRevision":"DATE_TEST",
      "codeAncienneCommune": "CODE_ANCIENNE_COMMUNE_TEST",
      "nomAncienneCommune": "NOM_ANCIENNE_COMMUNE_TEST",
      "isLieuDit": true
}

