### PR TITLE
ajout du banId aux fichiers legacy adresses et lieux-dits

### DIFF
--- a/lib/formatters/csv-legacy.cjs
+++ b/lib/formatters/csv-legacy.cjs
@@ -28,6 +28,9 @@ function getSource(rawSource) {
 function adresseToRow(a) {
   return {
     id: a.cleInterop,
+    id_ban_adresse: a.banId || '',
+    id_ban_toponyme: a.banIdMainCommonToponym || '',
+    id_ban_district: a.banIdDistrict || '',
     id_fantoir: getIdFantoirField(a.codeCommune, a.idVoie) || '',
     numero: a.numero,
     rep: a.suffixe || '',
@@ -60,6 +63,8 @@ function adresseToRow(a) {
 function lieuDitToRow(a) {
   return {
     id: a.idVoie,
+    id_ban_toponyme: a.banId || '',
+    id_ban_district: a.banIdDistrict || '',
     nom_lieu_dit: a.nomVoie,
     code_postal: a.codePostal || '',
     code_insee: a.codeCommune,


### PR DESCRIPTION
Cette PR permet d'ajouter des colonnes permettant l'export des banId dans les fichiers d'adressage historiques (adresses et lieux dits).

Pour tester vérifier en faisant un yarn dist (avec les données du département 60)

Ainsi lorsque les banId sont remplis on obtient : 
**fichier des adresses CSV BAL**
`uid_adresse`	cle_interop	commune_insee	commune_nom	...
`@a:83bb0c2e-2afb-4b73-b896-97d6328659ac @v:3587479b-8f4c-4f24-8c60-4d3fcbdf66f5 @c:1db0952a-3e58-47c3-931b-c2eb65d4d1bd`	60447_dwgt8o_00001	60447	Néry ...
**fichier des adresses legacy**
id	`id_ban_adresse	id_ban_toponyme	id_ban_district`	id_fantoir	numero	rep	nom_voie	code_postal	code_insee	nom_commune
60447_fp4p3f_00001	`83bb0c2e-2afb-4b73-b896-97d6328659ac	3587479b-8f4c-4f24-8c60-4d3fcbdf66f5	1db0952a-3e58-47c3-931b-c2eb65d4d1bd`		1		Impasse de Cornon	60320	60447	Néry

**lieu-dit dans le fichier CSV BAL**
`uid_adresse`	cle_interop	commune_insee	commune_nom	...
`@v:45e7b820-5d38-4eb5-8537-1a329c74212f @c:40cd8613-b131-4c7d-8c8e-fd44325f12b6`	60597_0083_99999	60597	Saint-Sauveur ...
**fichiers des lieux-dits legacy**
id	`id_ban_toponyme	id_ban_district`	id_fantoir	numero	rep	nom_voie	code_postal	code_insee	nom_commune
60597_0083	`45e7b820-5d38-4eb5-8537-1a329c74212f	40cd8613-b131-4c7d-8c8e-fd44325f12b6`	Place RenÃ© Eveloy	60320	60597	Saint-Sauveur

fix #207 
