### PR TITLE
ajout de la concaténation des LD France sur les données legacy

### DIFF
--- a/scripts/merge-france.sh
+++ b/scripts/merge-france.sh
@@ -2,3 +2,7 @@
 zcat adresses-01.csv.gz | head -n 1 | gzip > adresses-france.csv.gz.tmp
 for filename in $(ls adresses-*.csv.gz); do zcat $filename | sed 1d | gzip >> adresses-france.csv.gz.tmp; done
 mv adresses-france.csv.gz.tmp adresses-france.csv.gz
+
+zcat lieux-dits-01-beta.csv.gz | head -n 1 | gzip > lieux-dits-beta-france.csv.gz.tmp
+for filename in $(ls lieux-dits-*.csv.gz); do zcat $filename | sed 1d | gzip >> lieux-dits-beta-france.csv.gz.tmp; done
+mv lieux-dits-beta-france.csv.gz.tmp lieux-dits-beta-france.csv.gz


### PR DESCRIPTION
fix #306 

script permettant de tester en local le merge des données départementales legacy créées dans le dossier dist.
Ajout de la concaténation des LD sur la France.

Pour tester en local.
Faire un dist permet de générer les fichiers départementaux.
Puis lancer le script en mettant un chemin absolu devant les données et en remplaçant le département 01 par un département existant dans votre dist.

-> /d/ban-plateforme/dist/csv/ et remplacer 01 par un dép existant dans dist

Ce script est à adapter et déployer une fois la PR acceptée sur le serveur de production (cf script build-dist.sh)