### PR TITLE
renvoyer la tuile de rendu si le point est en bordure, pas seulement celle théorique

### DIFF
--- a/lib/util/geo.cjs
+++ b/lib/util/geo.cjs
@@ -1,7 +1,9 @@
 const {range, min, flatten} = require('lodash')
 const {concave, buffer, bbox, bboxPolygon, centroid, feature, featureCollection, truncate, pointOnFeature, booleanPointInPolygon, lineString, pointToLineDistance} = require('@turf/turf')
 const proj = require('@etalab/project-legal')
-const {pointToTile} = require('@mapbox/tilebelt')
+const {pointToTileFraction} = require('@mapbox/tilebelt')
+
+const extent = 4096
 
 function computeBufferedBbox(features, distanceInMeters) {
   if (!features || features.length === 0) {
@@ -73,12 +75,26 @@ function derivePositionProps(position, minZoom, maxZoom) {
     return {lon, lat, x, y}
   }
 
+  const nestedTile = []
   const tiles = range(minZoom, maxZoom + 1).map(zoom => {
-    const [x, y, z] = pointToTile(lon, lat, zoom)
+    const [xf, yf, z] = pointToTileFraction(lon, lat, zoom)
+
+    // Positon theroique
+    const x = Math.floor(xf)
+    const y = Math.floor(yf)
+
+    // Sauf que le rendu est sur mvt v2.1 sur une etendue (extent)
+    const overX = (Math.ceil(xf) - xf) < 1 / (2 * extent)
+    const overY = (Math.ceil(yf) - yf) < 1 / (2 * extent)
+    if (overX || overY) { // L'arrondit du pixel depassera l'etendue
+      console.log(`la position s'affichera sur la tuile suivante ${z}/${overX ? x + 1 : x}/${overY ? y + 1 : y}`)
+      nestedTile.push(`${z}/${overX ? x + 1 : x}/${overY ? y + 1 : y}`)
+    }
+
     return `${z}/${x}/${y}`
   })
 
-  return {lon, lat, x, y, tiles}
+  return {lon, lat, x, y, tiles: [...tiles, ...nestedTile]}
 }
 
 function getRings(polygon) {


### PR DESCRIPTION
# Context
Lors de la composition des bal un calcul de la tuile (xyz) correspondant aux positions ponctuelles des adresses et voie en vue d'un rendu et service tuilé.
Actuellement le service mvt renvoie bien l'ensemble des adresses présente dans la tuile , mais du fait de l'encodage certaines adresses en bordure sont considérées hors étendu et ne sont pas rendu par des clients (mapbox/maplibre).

il a environ 6k adresses dite fantômes (pour le niveau 14  dernier niveau servi par le serveur)
https://github.com/BaseAdresseNationale/ban-plateforme/issues/324

Cette PR propose d'inclure la tuile de rendu dans la liste des tuiles pour position si le point est en bordure.

# Effet
- affichage des positions où actuellement il y a default, 
- les 2 tuiles renverront la donnée du point en bordure. (un identifiant est déjà présent et permet donc de distinguer les doublons)

# Exemple
l'adresse actuelle de 74096_0114_00228 , à la position
```json
  "lon": 6.108398,
    "lat": 46.034484,
    "x": 940355.25,
    "y": 6553034.78,
    "tiles": [
        "12/2117/1456",
        "13/4234/2913",
        "14/8469/5826"
    ],
```
est en bordure de la tuile 13/4234/2913 et 14/8469/5826.
Sur adresse.data.gouv elle est actuellement invisible, Avec un client openlayer ou QGIS, le point de l'adresse est affiché par moitié de point 
![carte sous openlayer](https://github.com/BaseAdresseNationale/ban-plateforme/assets/62593305/7689573f-377a-4fc1-a74e-4adc9e8bc09f)

avec ce patch et un recalcul, le [lookup de l'adresse 228 Grand'rue Cruseilles 74096_0114_00228](https://plateforme.adresse.data.gouv.fr/lookup/74096_0114_00228) aura 2 tuiles en plus 13/4235/2913 et  14/8469/5826 et l'explorer adresse présentera le point 228 graphiquement.

Le recalcul peut s'obtenir par demande de composition de la commune.
