### PR TITLE
Strict mode and no unknown on validation

### DIFF
--- a/lib/api/address/__mocks__/address-data-mock.js
+++ b/lib/api/address/__mocks__/address-data-mock.js
@@ -12,7 +12,7 @@ export const addressMock = [
         coordinates: [1.23, 2.34]
       }
     }],
-    updateDate: '2023-04-12'
+    updateDate: new Date('2023-04-12')
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
@@ -28,7 +28,7 @@ export const addressMock = [
         coordinates: [1.24, 2.34]
       }
     }],
-    updateDate: '2023-04-12'
+    updateDate: new Date('2023-04-12')
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000c',
@@ -43,7 +43,7 @@ export const addressMock = [
         coordinates: [1.25, 2.34]
       }
     }],
-    updateDate: '2023-04-12'
+    updateDate: new Date('2023-04-12')
   }
 ]
 
@@ -84,7 +84,7 @@ export const bddAddressMock = [
         coordinates: [1.25, 2.34]
       }
     }],
-    updateDate: '2023-04-12'
+    updateDate: new Date('2023-04-12')
   },
   {
     id: '00000000-0000-4fff-9fff-00000000002b',
@@ -99,7 +99,7 @@ export const bddAddressMock = [
         coordinates: [1.25, 2.34]
       }
     }],
-    updateDate: '2023-04-12'
+    updateDate: new Date('2023-04-12')
   },
   {
     id: '00000000-0000-4fff-9fff-00000000002c',
@@ -114,6 +114,6 @@ export const bddAddressMock = [
         coordinates: [1.25, 2.34]
       }
     }],
-    updateDate: '2023-04-12'
+    updateDate: new Date('2023-04-12')
   }
 ]

--- a/lib/api/address/schema.js
+++ b/lib/api/address/schema.js
@@ -6,12 +6,12 @@ const PositionTypes = ['entrance', 'building', 'staircase identifier', 'unit ide
 const positionSchema = object({
   type: string().trim().oneOf(PositionTypes).required(),
   geometry: geometrySchema.required(),
-})
+}).noUnknown()
 
 const metaSchema = object({
   cadastre: cadastreSchema,
   bal: balSchema,
-})
+}).noUnknown()
 
 export const banAddressSchema = object({
   id: banID.required(),
@@ -25,7 +25,7 @@ export const banAddressSchema = object({
   positions: array().of(positionSchema).required(),
   updateDate: date().required(),
   meta: metaSchema
-})
+}).noUnknown()
 
 export const banAddressSchemaForPatch = object({
   id: banID.required(),
@@ -39,7 +39,7 @@ export const banAddressSchemaForPatch = object({
   positions: array().of(positionSchema).default(null).nullable(),
   updateDate: date(),
   meta: metaSchema
-})
+}).noUnknown()
 
 export const addressDefaultOptionalValues = {
   secondaryCommonToponymIDs: [],

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -128,7 +128,7 @@ describe('checkAddressesRequest', () => {
   })
 
   it('Available addresses on update', async () => {
-    const addressesValidation = await checkAddressesRequest(bddAddressMock.map(addr => ({...addr, certifie: true})), 'update')
+    const addressesValidation = await checkAddressesRequest(bddAddressMock.map(addr => ({...addr, certified: true})), 'update')
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)

--- a/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
+++ b/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
@@ -10,7 +10,7 @@ export const commonToponymMock = [
       type: 'Point',
       coordinates: [1.2345, 2.3456]
     },
-    updateDate: '2023-04-24'
+    updateDate: new Date('2023-04-24')
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
@@ -23,7 +23,7 @@ export const commonToponymMock = [
       type: 'Point',
       coordinates: [1.2345, 2.3456]
     },
-    updateDate: '2023-04-24'
+    updateDate: new Date('2023-04-24')
   }
 ]
 
@@ -45,7 +45,7 @@ export const commonToponymMockForPatch = [
       type: 'Point',
       coordinates: [1.2346, 2.3456]
     },
-    updateDate: '2023-04-24'
+    updateDate: new Date('2023-04-24')
   }
 ]
 
@@ -61,7 +61,7 @@ export const bddCommonToponymMock = [
       type: 'Point',
       coordinates: [1.2345, 2.3456]
     },
-    updateDate: '2023-04-24'
+    updateDate: new Date('2023-04-24')
   },
   {
     id: '00000000-0000-4fff-9fff-00000000001b',
@@ -74,7 +74,7 @@ export const bddCommonToponymMock = [
       type: 'Point',
       coordinates: [1.2345, 2.3456]
     },
-    updateDate: '2023-04-24'
+    updateDate: new Date('2023-04-24')
   },
   {
     id: '00000000-0000-4fff-9fff-00000000001c',
@@ -87,6 +87,6 @@ export const bddCommonToponymMock = [
       type: 'Point',
       coordinates: [1.2345, 2.3456]
     },
-    updateDate: '2023-04-24'
+    updateDate: new Date('2023-04-24')
   }
 ]

--- a/lib/api/common-toponym/schema.js
+++ b/lib/api/common-toponym/schema.js
@@ -4,7 +4,7 @@ import {banID, geometrySchema, labelSchema, cadastreSchema, balSchema} from '../
 const metaSchema = object({
   cadastre: cadastreSchema,
   bal: balSchema,
-})
+}).noUnknown()
 
 export const banCommonToponymSchema = object({
   id: banID.required(),
@@ -13,7 +13,7 @@ export const banCommonToponymSchema = object({
   geometry: geometrySchema.default(null).nullable(),
   updateDate: date().required(),
   meta: metaSchema
-})
+}).noUnknown()
 
 export const banCommonToponymSchemaForPatch = object({
   id: banID.required(),
@@ -22,7 +22,7 @@ export const banCommonToponymSchemaForPatch = object({
   geometry: geometrySchema.default(null).nullable(),
   updateDate: date(),
   meta: metaSchema
-})
+}).noUnknown()
 
 export const commonToponymDefaultOptionalValues = {
   geometry: undefined,

--- a/lib/api/common-toponym/utils.spec.js
+++ b/lib/api/common-toponym/utils.spec.js
@@ -111,7 +111,7 @@ describe('checkCommonToponymsRequest', () => {
   })
 
   it('Available commonToponyms on update', async () => {
-    const commonToponymsValidation = await checkCommonToponymsRequest(bddCommonToponymMock.map(commonToponym => ({...commonToponym, label: [{isoCode: 'fra', value: 'Rue de la mouette'}]})), 'update')
+    const commonToponymsValidation = await checkCommonToponymsRequest(bddCommonToponymMock.map(commonToponym => ({...commonToponym, labels: [{isoCode: 'fra', value: 'Rue de la mouette'}]})), 'update')
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(commonToponymsValidation?.isValid).toBe(true)

--- a/lib/api/district/__mocks__/district-data-mock.js
+++ b/lib/api/district/__mocks__/district-data-mock.js
@@ -5,7 +5,7 @@ export const districtMock = [
       isoCode: 'fra',
       value: 'Commune A'
     }],
-    updateDate: '2023-06-22',
+    updateDate: new Date('2023-06-22'),
     meta: {
       insee: {
         cog: '12345'
@@ -18,7 +18,7 @@ export const districtMock = [
       isoCode: 'fra',
       value: 'Commune B'
     }],
-    updateDate: '2023-06-22',
+    updateDate: new Date('2023-06-22'),
     meta: {
       insee: {
         cog: '12346'
@@ -37,7 +37,7 @@ export const districtMockForPatch = [
   },
   {
     id: '00000000-0000-4fff-9fff-000000000001',
-    updateDate: '2023-06-23',
+    updateDate: new Date('2023-06-23'),
   },
   {
     id: '00000000-0000-4fff-9fff-000000000002',
@@ -56,7 +56,7 @@ export const bddDistrictMock = [
       isoCode: 'fra',
       value: 'Commune C'
     }],
-    updateDate: '2023-06-22',
+    updateDate: new Date('2023-06-22'),
     meta: {
       insee: {
         cog: '54321'
@@ -69,7 +69,7 @@ export const bddDistrictMock = [
       isoCode: 'fra',
       value: 'Commune D'
     }],
-    updateDate: '2023-06-22',
+    updateDate: new Date('2023-06-22'),
     meta: {
       insee: {
         cog: '54322'
@@ -82,7 +82,7 @@ export const bddDistrictMock = [
       isoCode: 'fra',
       value: 'Commune E'
     }],
-    updateDate: '2023-06-22',
+    updateDate: new Date('2023-06-22'),
     meta: {
       insee: {
         cog: '54323'

--- a/lib/api/district/schema.js
+++ b/lib/api/district/schema.js
@@ -3,12 +3,12 @@ import {banID, labelSchema, inseeSchema, balSchema} from '../schema.js'
 
 const configSchema = object({
   useBanId: bool()
-})
+}).noUnknown()
 
 const metaSchema = object({
   insee: inseeSchema,
   bal: balSchema,
-})
+}).noUnknown()
 
 export const banDistrictSchema = object({
   id: banID.required(),
@@ -16,7 +16,7 @@ export const banDistrictSchema = object({
   updateDate: date().required(),
   config: configSchema,
   meta: metaSchema
-})
+}).noUnknown()
 
 export const banDistrictSchemaForPatch = object({
   id: banID.required(),
@@ -24,7 +24,7 @@ export const banDistrictSchemaForPatch = object({
   updateDate: date(),
   config: configSchema,
   meta: metaSchema.default(null).nullable(),
-})
+}).noUnknown()
 
 export const districtDefaultOptionalValues = {
   config: undefined,

--- a/lib/api/district/utils.spec.js
+++ b/lib/api/district/utils.spec.js
@@ -94,7 +94,7 @@ describe('checkDistrictsRequest', () => {
   })
 
   it('Available districts on update', async () => {
-    const districtsValidation = await checkDistrictsRequest(bddDistrictMock.map(district => ({...district, label: [{isoCode: 'fra', value: 'commune F'}]})), 'update')
+    const districtsValidation = await checkDistrictsRequest(bddDistrictMock.map(district => ({...district, labels: [{isoCode: 'fra', value: 'commune F'}]})), 'update')
     const testSchema = await districtsValidationSchema.isValid(districtsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(districtsValidation?.isValid).toBe(true)

--- a/lib/api/helper.js
+++ b/lib/api/helper.js
@@ -77,7 +77,7 @@ export const checkIdsShema = async (err = 'Invalid IDs format', ids, schema) => 
 
 const dataSchemaValidation = async (data, schema) => {
   try {
-    await schema.validate(data, {abortEarly: false, stripUnknown: true})
+    await schema.validate(data, {strict: true, abortEarly: false})
   } catch (error) {
     return dataValidationReportFrom(false, `Invalid data format (id: ${data.id})`, error.errors)
   }

--- a/lib/api/schema.js
+++ b/lib/api/schema.js
@@ -5,20 +5,20 @@ export const banID = string().trim().uuid()
 export const labelSchema = object({
   isoCode: string().trim().length(3).required(),
   value: string().trim().required(),
-})
+}).noUnknown()
 
 export const geometrySchema = object({
   type: string().trim().matches(/^Point$/).required(),
   coordinates: array().length(2).of(number()).required(),
-})
+}).noUnknown()
 
 export const inseeSchema = object({
   cog: string().trim().length(5).required()
-})
+}).noUnknown()
 
 export const cadastreSchema = object({
   ids: array().of(string().trim())
-})
+}).noUnknown()
 
 export const balSchema = object({
   idRevision: string().trim(),
@@ -26,5 +26,5 @@ export const balSchema = object({
   codeAncienneCommune: string().trim(),
   nomAncienneCommune: string().trim(),
   isLieuDit: boolean()
-})
+}).noUnknown()
 


### PR DESCRIPTION
# Context

We are using "yup" package to validate ban-ID data schema.

# Enhancement

This PR aims to add : 
- strictMode on validation => validation more strict. For example, dates have to be Date() and not strings
- noUnknown() => cannot have unknown properties in the schemas