### PR TITLE
Delta report and id-fix hash

### DIFF
--- a/lib/api/address/__mocks__/address-data-mock.js
+++ b/lib/api/address/__mocks__/address-data-mock.js
@@ -12,7 +12,12 @@ export const addressMock = [
         coordinates: [1.23, 2.34]
       }
     }],
-    updateDate: new Date('2023-04-12')
+    updateDate: new Date('2023-04-12'),
+    meta: {
+      idfix: {
+        hash: '00c6ee2e21a7548de6260cf72c4f4b5b'
+      }
+    }
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
@@ -28,7 +33,12 @@ export const addressMock = [
         coordinates: [1.24, 2.34]
       }
     }],
-    updateDate: new Date('2023-04-12')
+    updateDate: new Date('2023-04-12'),
+    meta: {
+      idfix: {
+        hash: '58833651db311ba4bc11cb26b1900b0f'
+      }
+    }
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000c',
@@ -43,7 +53,12 @@ export const addressMock = [
         coordinates: [1.25, 2.34]
       }
     }],
-    updateDate: new Date('2023-04-12')
+    updateDate: new Date('2023-04-12'),
+    meta: {
+      idfix: {
+        hash: '1a4ead8b39d17dfe89418452c9bba770'
+      }
+    }
   }
 ]
 
@@ -84,7 +99,12 @@ export const bddAddressMock = [
         coordinates: [1.25, 2.34]
       }
     }],
-    updateDate: new Date('2023-04-12')
+    updateDate: new Date('2023-04-12'),
+    meta: {
+      idfix: {
+        hash: 'd80b0d6020798ff15e8d5416911201aa'
+      }
+    }
   },
   {
     id: '00000000-0000-4fff-9fff-00000000002b',
@@ -99,7 +119,12 @@ export const bddAddressMock = [
         coordinates: [1.25, 2.34]
       }
     }],
-    updateDate: new Date('2023-04-12')
+    updateDate: new Date('2023-04-12'),
+    meta: {
+      idfix: {
+        hash: '2ce8a4621b2843043725992ab2a61acc'
+      }
+    }
   },
   {
     id: '00000000-0000-4fff-9fff-00000000002c',
@@ -114,6 +139,11 @@ export const bddAddressMock = [
         coordinates: [1.25, 2.34]
       }
     }],
-    updateDate: new Date('2023-04-12')
+    updateDate: new Date('2023-04-12'),
+    meta: {
+      idfix: {
+        hash: 'be796e420febda49c29e38745db3cae2'
+      }
+    }
   }
 ]

--- a/lib/api/address/__mocks__/address-models.js
+++ b/lib/api/address/__mocks__/address-models.js
@@ -4,7 +4,7 @@ export async function getAddresses(addressIDs) {
   return bddAddressMock.filter(({id}) => addressIDs.includes(id))
 }
 
-export async function getAllAddressIDsFromDistrict(districtID) {
+export async function getAllAddressIDsWithHashFromDistrict(districtID) {
   return bddAddressMock.filter(({districtID: districtIDAddress}) => districtIDAddress === districtID).map(({id}) => id)
 }
 

--- a/lib/api/address/__mocks__/address-models.js
+++ b/lib/api/address/__mocks__/address-models.js
@@ -5,7 +5,7 @@ export async function getAddresses(addressIDs) {
 }
 
 export async function getAllAddressIDsWithHashFromDistrict(districtID) {
-  return bddAddressMock.filter(({districtID: districtIDAddress}) => districtIDAddress === districtID).map(({id}) => id)
+  return bddAddressMock.filter(({districtID: districtIDAddress}) => districtIDAddress === districtID).map(({id, meta}) => ({id, hash: meta?.idfix?.hash}))
 }
 
 export async function getAllAddressIDsOutsideDistrict(addressIDs, districtID) {

--- a/lib/api/address/models.js
+++ b/lib/api/address/models.js
@@ -5,9 +5,9 @@ export const getAddress = addressID => Address.findByPk(addressID, {raw: true})
 
 export const getAddresses = addressIDs => Address.findAll({where: {id: addressIDs}, raw: true})
 
-export const getAllAddressIDsFromDistrict = async districtID => {
-  const addresses = await Address.findAll({where: {districtID}, attributes: ['id'], raw: true})
-  return addresses.map(address => address.id)
+export const getAllAddressIDsWithHashFromDistrict = async districtID => {
+  const addresses = await Address.findAll({where: {districtID}, attributes: ['id', 'meta'], raw: true})
+  return addresses.map(address => ({id: address.id, hash: address.meta?.idfix?.hash}))
 }
 
 export const getAllAddressIDsOutsideDistrict = async (addressIDs, districtID) => {

--- a/lib/api/address/routes.js
+++ b/lib/api/address/routes.js
@@ -189,14 +189,14 @@ app.post('/delete', auth, analyticsMiddleware, async (req, res) => {
 app.post('/delta-report', auth, analyticsMiddleware, async (req, res) => {
   let response
   try {
-    const {addressIDs, districtID} = req.body
+    const {data, districtID} = req.body
 
-    if (!addressIDs || !districtID) {
+    if (!data || !districtID) {
       res.status(404).send('Wrong request format')
       return
     }
 
-    const deltaReport = await getDeltaReport(addressIDs, districtID)
+    const deltaReport = await getDeltaReport(data, districtID)
     response = {
       date: new Date(),
       status: 'success',

--- a/lib/api/address/schema.js
+++ b/lib/api/address/schema.js
@@ -1,5 +1,5 @@
 import {object, string, number, boolean, array, date} from 'yup'
-import {banID, geometrySchema, labelSchema, cadastreSchema, balSchema} from '../schema.js'
+import {banID, geometrySchema, labelSchema, cadastreSchema, balSchema, idfixSchema} from '../schema.js'
 
 const PositionTypes = ['entrance', 'building', 'staircase identifier', 'unit identifier', 'utility service', 'postal delivery', 'parcel', 'segment', 'other']
 
@@ -11,6 +11,7 @@ const positionSchema = object({
 const metaSchema = object({
   cadastre: cadastreSchema,
   bal: balSchema,
+  idfix: idfixSchema,
 }).noUnknown()
 
 export const banAddressSchema = object({

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -1,6 +1,6 @@
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfCommonToponymsExist, checkIfDistrictsExist} from '../helper.js'
 import {banID} from '../schema.js'
-import {getAddresses, getAllAddressIDsFromDistrict, getAllAddressIDsOutsideDistrict} from './models.js'
+import {getAddresses, getAllAddressIDsWithHashFromDistrict, getAllAddressIDsOutsideDistrict} from './models.js'
 import {banAddressSchema} from './schema.js'
 
 const getExistingAddressIDs = async addressIDs => {
@@ -82,25 +82,27 @@ export const checkAddressesRequest = async (addresses, actionType) => {
   return report
 }
 
-export const getDeltaReport = async (addressIDs, districtID) => {
-  const allAddressIDsFromCommune = await getAllAddressIDsFromDistrict(districtID)
-  const allAddressIDsFromDistrictSet = new Set(allAddressIDsFromCommune)
-  const addressIDsSet = new Set(addressIDs)
+export const getDeltaReport = async (addressIDsWithHash, districtID) => {
+  const addressIDsWithHashMap = new Map(addressIDsWithHash.map(({id, hash}) => [id, hash]))
+  const allAddressIDsWithHashFromDistrict = await getAllAddressIDsWithHashFromDistrict(districtID)
+  const allAddressIDsWithHashFromDistrictMap = new Map(allAddressIDsWithHashFromDistrict.map(({id, hash}) => [id, hash]))
 
   let idsToCreate = []
   const idsToUpdate = []
   const idsToDelete = []
 
-  for (const id of addressIDs) {
-    if (allAddressIDsFromDistrictSet.has(id)) {
-      idsToUpdate.push(id)
+  for (const [id, hash] of addressIDsWithHashMap) {
+    if (allAddressIDsWithHashFromDistrictMap.has(id)) {
+      if (allAddressIDsWithHashFromDistrictMap.get(id) !== hash) {
+        idsToUpdate.push(id)
+      }
     } else {
       idsToCreate.push(id)
     }
   }
 
-  for (const id of allAddressIDsFromCommune) {
-    if (!addressIDsSet.has(id)) {
+  for (const id of allAddressIDsWithHashFromDistrictMap.keys()) {
+    if (!addressIDsWithHashMap.has(id)) {
       idsToDelete.push(id)
     }
   }

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -5,7 +5,7 @@ import {addressMock, addressMockForPatch, bddAddressMock} from './__mocks__/addr
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/address-models.js'))
 jest.unstable_mockModule('../common-toponym/models.js', async () => import('../common-toponym/__mocks__/common-toponym-models.js'))
 jest.unstable_mockModule('../district/models.js', async () => import('../district/__mocks__/district-models.js'))
-const {checkAddressesIDsRequest, checkAddressesRequest} = await import('./utils.js')
+const {checkAddressesIDsRequest, checkAddressesRequest, getDeltaReport} = await import('./utils.js')
 
 const addressesValidationSchema = object({
   isValid: bool().required(),
@@ -163,5 +163,42 @@ describe('checkAddressesRequest', () => {
     const testSchema = await addressesValidationSchema.isValid(addressesValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(addressesValidation?.isValid).toBe(true)
+  })
+})
+
+describe('getDeltaReport', () => {
+  it('Should return all ids to create and all ids from bdd to delete', async () => {
+    const districtID = '00000000-0000-4fff-9fff-000000000000'
+    const data = addressMock.map(({id, meta}) => ({id, hash: meta?.idfix?.hash}))
+    const result = await getDeltaReport(data, districtID)
+    expect(result).toEqual({
+      idsToCreate: addressMock.map(({id}) => id),
+      idsToUpdate: [],
+      idsToDelete: bddAddressMock.map(({id}) => id),
+      idsUnauthorized: []
+    })
+  })
+  it('Should not return anything to update as hashes are equals', async () => {
+    const districtID = '00000000-0000-4fff-9fff-000000000000'
+    const data = bddAddressMock.map(({id, meta}) => ({id, hash: meta?.idfix?.hash}))
+    const result = await getDeltaReport(data, districtID)
+    expect(result).toEqual({
+      idsToCreate: [],
+      idsToUpdate: [],
+      idsToDelete: [],
+      idsUnauthorized: []
+    })
+  })
+  it('Should return only one id to update as hashes are different', async () => {
+    const districtID = '00000000-0000-4fff-9fff-000000000000'
+    const data = bddAddressMock.map(({id, meta}) => ({id, hash: meta?.idfix?.hash}))
+    data[0].hash = 'new-hash'
+    const result = await getDeltaReport(data, districtID)
+    expect(result).toEqual({
+      idsToCreate: [],
+      idsToUpdate: [bddAddressMock[0].id],
+      idsToDelete: [],
+      idsUnauthorized: []
+    })
   })
 })

--- a/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
+++ b/lib/api/common-toponym/__mocks__/common-toponym-data-mock.js
@@ -10,7 +10,12 @@ export const commonToponymMock = [
       type: 'Point',
       coordinates: [1.2345, 2.3456]
     },
-    updateDate: new Date('2023-04-24')
+    updateDate: new Date('2023-04-24'),
+    meta: {
+      idfix: {
+        hash: '00c6ee2e21a7548de6260cf72c4f4b5b'
+      }
+    }
   },
   {
     id: '00000000-0000-4fff-9fff-00000000000b',
@@ -23,7 +28,12 @@ export const commonToponymMock = [
       type: 'Point',
       coordinates: [1.2345, 2.3456]
     },
-    updateDate: new Date('2023-04-24')
+    updateDate: new Date('2023-04-24'),
+    meta: {
+      idfix: {
+        hash: '58833651db311ba4bc11cb26b1900b0f'
+      }
+    }
   }
 ]
 
@@ -61,7 +71,12 @@ export const bddCommonToponymMock = [
       type: 'Point',
       coordinates: [1.2345, 2.3456]
     },
-    updateDate: new Date('2023-04-24')
+    updateDate: new Date('2023-04-24'),
+    meta: {
+      idfix: {
+        hash: '1a4ead8b39d17dfe89418452c9bba770'
+      }
+    }
   },
   {
     id: '00000000-0000-4fff-9fff-00000000001b',
@@ -74,7 +89,12 @@ export const bddCommonToponymMock = [
       type: 'Point',
       coordinates: [1.2345, 2.3456]
     },
-    updateDate: new Date('2023-04-24')
+    updateDate: new Date('2023-04-24'),
+    meta: {
+      idfix: {
+        hash: 'd80b0d6020798ff15e8d5416911201aa'
+      }
+    }
   },
   {
     id: '00000000-0000-4fff-9fff-00000000001c',
@@ -87,6 +107,11 @@ export const bddCommonToponymMock = [
       type: 'Point',
       coordinates: [1.2345, 2.3456]
     },
-    updateDate: new Date('2023-04-24')
+    updateDate: new Date('2023-04-24'),
+    meta: {
+      idfix: {
+        hash: '2ce8a4621b2843043725992ab2a61acc'
+      }
+    }
   }
 ]

--- a/lib/api/common-toponym/__mocks__/common-toponym-models.js
+++ b/lib/api/common-toponym/__mocks__/common-toponym-models.js
@@ -4,7 +4,7 @@ export async function getCommonToponyms(commonToponymIDs) {
   return bddCommonToponymMock.filter(({id}) => commonToponymIDs.includes(id))
 }
 
-export async function getAllCommonToponymIDsFromDistrict(districtID) {
+export async function getAllCommonToponymIDsWithHashFromDistrict(districtID) {
   return bddCommonToponymMock.filter(({districtID: districtIDCommonToponym}) => districtIDCommonToponym === districtID).map(({id}) => id)
 }
 

--- a/lib/api/common-toponym/__mocks__/common-toponym-models.js
+++ b/lib/api/common-toponym/__mocks__/common-toponym-models.js
@@ -5,7 +5,7 @@ export async function getCommonToponyms(commonToponymIDs) {
 }
 
 export async function getAllCommonToponymIDsWithHashFromDistrict(districtID) {
-  return bddCommonToponymMock.filter(({districtID: districtIDCommonToponym}) => districtIDCommonToponym === districtID).map(({id}) => id)
+  return bddCommonToponymMock.filter(({districtID: districtIDCommonToponym}) => districtIDCommonToponym === districtID).map(({id, meta}) => ({id, hash: meta?.idfix?.hash}))
 }
 
 export async function getAllCommonToponymIDsOutsideDistrict(commonToponymIDs, districtID) {

--- a/lib/api/common-toponym/models.js
+++ b/lib/api/common-toponym/models.js
@@ -5,11 +5,11 @@ export const getCommonToponym = commonToponymID => CommonToponym.findByPk(common
 
 export const getCommonToponyms = commonToponymIDs => CommonToponym.findAll({where: {id: commonToponymIDs}, raw: true})
 
-export const getAllCommonToponymIDsFromDistrict = async districtID => {
+export const getAllCommonToponymIDsWithHashFromDistrict = async districtID => {
   const commonToponyms = await CommonToponym.findAll(
-    {where: {districtID}, attributes: ['id'], raw: true}
+    {where: {districtID}, attributes: ['id', 'meta'], raw: true}
   )
-  return commonToponyms.map(commonToponym => commonToponym.id)
+  return commonToponyms.map(commonToponym => ({id: commonToponym.id, hash: commonToponym.meta?.idfix?.hash}))
 }
 
 export const getAllCommonToponymIDsOutsideDistrict = async (commonToponymIDs, districtID) => {

--- a/lib/api/common-toponym/routes.js
+++ b/lib/api/common-toponym/routes.js
@@ -189,14 +189,14 @@ app.post('/delete', auth, analyticsMiddleware, async (req, res) => {
 app.post('/delta-report', auth, analyticsMiddleware, async (req, res) => {
   let response
   try {
-    const {commonToponymIDs, districtID} = req.body
+    const {data, districtID} = req.body
 
-    if (!commonToponymIDs || !districtID) {
+    if (!data || !districtID) {
       res.status(404).send('Wrong request format')
       return
     }
 
-    const deltaReport = await getDeltaReport(commonToponymIDs, districtID)
+    const deltaReport = await getDeltaReport(data, districtID)
     response = {
       date: new Date(),
       status: 'success',

--- a/lib/api/common-toponym/schema.js
+++ b/lib/api/common-toponym/schema.js
@@ -1,9 +1,10 @@
 import {object, array, date} from 'yup'
-import {banID, geometrySchema, labelSchema, cadastreSchema, balSchema} from '../schema.js'
+import {banID, geometrySchema, labelSchema, cadastreSchema, balSchema, idfixSchema} from '../schema.js'
 
 const metaSchema = object({
   cadastre: cadastreSchema,
   bal: balSchema,
+  idfix: idfixSchema,
 }).noUnknown()
 
 export const banCommonToponymSchema = object({

--- a/lib/api/common-toponym/utils.js
+++ b/lib/api/common-toponym/utils.js
@@ -1,6 +1,6 @@
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfDistrictsExist} from '../helper.js'
 import {banID} from '../schema.js'
-import {getCommonToponyms, getAllCommonToponymIDsFromDistrict, getAllCommonToponymIDsOutsideDistrict} from './models.js'
+import {getCommonToponyms, getAllCommonToponymIDsWithHashFromDistrict, getAllCommonToponymIDsOutsideDistrict} from './models.js'
 import {banCommonToponymSchema} from './schema.js'
 
 const getExistingCommonToponymIDs = async commonToponymIDs => {
@@ -74,25 +74,27 @@ export const checkCommonToponymsRequest = async (commonToponyms, actionType) => 
   return report
 }
 
-export const getDeltaReport = async (commonToponymIDs, districtID) => {
-  const allCommonToponymIDsFromCommune = await getAllCommonToponymIDsFromDistrict(districtID)
-  const allCommonToponymIDsFromDistrictSet = new Set(allCommonToponymIDsFromCommune)
-  const commonToponymIDsSet = new Set(commonToponymIDs)
+export const getDeltaReport = async (commonToponymIDsWithHash, districtID) => {
+  const commonToponymIDsWithHashMap = new Map(commonToponymIDsWithHash.map(({id, hash}) => [id, hash]))
+  const allCommonToponymIDsWithHashFromDistrict = await getAllCommonToponymIDsWithHashFromDistrict(districtID)
+  const allCommonToponymIDsWithHashFromDistrictMap = new Map(allCommonToponymIDsWithHashFromDistrict.map(({id, hash}) => [id, hash]))
 
   let idsToCreate = []
   const idsToUpdate = []
   const idsToDelete = []
 
-  for (const id of commonToponymIDs) {
-    if (allCommonToponymIDsFromDistrictSet.has(id)) {
-      idsToUpdate.push(id)
+  for (const [id, hash] of commonToponymIDsWithHashMap) {
+    if (allCommonToponymIDsWithHashFromDistrictMap.has(id)) {
+      if (allCommonToponymIDsWithHashFromDistrictMap.get(id) !== hash) {
+        idsToUpdate.push(id)
+      }
     } else {
       idsToCreate.push(id)
     }
   }
 
-  for (const id of allCommonToponymIDsFromCommune) {
-    if (!commonToponymIDsSet.has(id)) {
+  for (const id of allCommonToponymIDsWithHashFromDistrictMap.keys()) {
+    if (!commonToponymIDsWithHashMap.has(id)) {
       idsToDelete.push(id)
     }
   }

--- a/lib/api/common-toponym/utils.spec.js
+++ b/lib/api/common-toponym/utils.spec.js
@@ -4,7 +4,7 @@ import {commonToponymMock, commonToponymMockForPatch, bddCommonToponymMock} from
 
 jest.unstable_mockModule('./models.js', async () => import('./__mocks__/common-toponym-models.js'))
 jest.unstable_mockModule('../district/models.js', async () => import('../district/__mocks__/district-models.js'))
-const {checkCommonToponymsRequest, checkCommonToponymsIDsRequest} = await import('./utils.js')
+const {checkCommonToponymsRequest, checkCommonToponymsIDsRequest, getDeltaReport} = await import('./utils.js')
 
 const commonToponymsValidationSchema = object({
   isValid: bool().required(),
@@ -138,5 +138,42 @@ describe('checkCommonToponymsRequest', () => {
     const testSchema = await commonToponymsValidationSchema.isValid(commonToponymsValidation, {strict: true})
     expect(testSchema).toBe(true)
     expect(commonToponymsValidation?.isValid).toBe(true)
+  })
+})
+
+describe('getDeltaReport', () => {
+  it('Should return all ids to create and all ids from bdd to delete', async () => {
+    const districtID = '00000000-0000-4fff-9fff-000000000000'
+    const data = commonToponymMock.map(({id, meta}) => ({id, hash: meta?.idfix?.hash}))
+    const result = await getDeltaReport(data, districtID)
+    expect(result).toEqual({
+      idsToCreate: commonToponymMock.map(({id}) => id),
+      idsToUpdate: [],
+      idsToDelete: bddCommonToponymMock.map(({id}) => id),
+      idsUnauthorized: []
+    })
+  })
+  it('Should not return anything to update as hashes are equals', async () => {
+    const districtID = '00000000-0000-4fff-9fff-000000000000'
+    const data = bddCommonToponymMock.map(({id, meta}) => ({id, hash: meta?.idfix?.hash}))
+    const result = await getDeltaReport(data, districtID)
+    expect(result).toEqual({
+      idsToCreate: [],
+      idsToUpdate: [],
+      idsToDelete: [],
+      idsUnauthorized: []
+    })
+  })
+  it('Should return only one id to update as hashes are different', async () => {
+    const districtID = '00000000-0000-4fff-9fff-000000000000'
+    const data = bddCommonToponymMock.map(({id, meta}) => ({id, hash: meta?.idfix?.hash}))
+    data[0].hash = 'new-hash'
+    const result = await getDeltaReport(data, districtID)
+    expect(result).toEqual({
+      idsToCreate: [],
+      idsToUpdate: [bddCommonToponymMock[0].id],
+      idsToDelete: [],
+      idsUnauthorized: []
+    })
   })
 })

--- a/lib/api/schema.js
+++ b/lib/api/schema.js
@@ -24,3 +24,6 @@ export const balSchema = object({
   isLieuDit: boolean()
 }).noUnknown()
 
+export const idfixSchema = object({
+  hash: string().trim(),
+}).noUnknown()


### PR DESCRIPTION
# Context

When sending data from id-fix, we need to be able to ONLY update the addresses or toponyms that are different from the database.

# Enhancement

This PR aims to add the following behavior for the delta-report routes : 
- retrieve the hash (md5) from the id-fix meta
- compare the hash to the one sent <= if hashes are different, the delta-report route must add the address/toponym IDs to the "update" key or the object returned. If not, delta-report routes must not return them.

# How to test

1- Clone the branch
2- Also clone the branch of this PR : https://github.com/BaseAdresseNationale/id-fix/pull/70
3- Use the initBALIntoBAN from id-fix to push a BAL => md5 hashes are going to be stored in the database the first time
4- Use the same script a second time => nothing should be updated as md5 are the same.

Info : to check if data is updated, you can either check the logs or the update dates in the postgresql DB