### PR TITLE
modification du fichier csv historique avec ids

### DIFF
--- a/lib/formatters/csv-legacy.cjs
+++ b/lib/formatters/csv-legacy.cjs
@@ -60,9 +60,6 @@ function adresseToRow(a) {
 function adresseToRowWithIds(a) {
   return {
     id: a.cleInterop,
-    id_ban_adresse: a.banId || '',
-    id_ban_toponyme: a.banIdMainCommonToponym || '',
-    id_ban_district: a.banIdDistrict || '',
     id_fantoir: getIdFantoirField(a.codeCommune, a.idVoie) || '',
     numero: a.numero,
     rep: a.suffixe || '',
@@ -88,15 +85,16 @@ function adresseToRowWithIds(a) {
     source_nom_voie: getSource(a.sourceNomVoie) || '',
 
     certification_commune: a.certifie ? '1' : '0',
-    cad_parcelles: a.parcelles ? a.parcelles.join('|') : ''
+    cad_parcelles: a.parcelles ? a.parcelles.join('|') : '',
+    id_ban_adresse: a.banId || '',
+    id_ban_toponyme: a.banIdMainCommonToponym || '',
+    id_ban_commune: a.banIdDistrict || '',
   }
 }
 
 function lieuDitToRowWithIds(a) {
   return {
     id: a.idVoie,
-    id_ban_toponyme: a.banId || '',
-    id_ban_district: a.banIdDistrict || '',
     nom_lieu_dit: a.nomVoie,
     code_postal: a.codePostal || '',
     code_insee: a.codeCommune,
@@ -110,7 +108,9 @@ function lieuDitToRowWithIds(a) {
     lat: a.lat || '',
 
     source_position: a.source,
-    source_nom_voie: a.source
+    source_nom_voie: a.source,
+    id_ban_toponyme: a.banId || '',
+    id_ban_commune: a.banIdDistrict || ''
   }
 }
 


### PR DESCRIPTION
fix #335 

Les colonnes d'identifiants passent en fin de fichier, le nom de la colonne contenant le BanId de la commune passe à idn_ban_commune conformément au nom du format BAL AITF 1.4.

A faire ensuite en production rajouter la partie de script permettant de produire les fichiers France entière