### PR TITLE
Added json to text conversion for compatibility postgis version 2.5

### DIFF
--- a/lib/api/consumers/export-to-exploitation-db-consumer.js
+++ b/lib/api/consumers/export-to-exploitation-db-consumer.js
@@ -57,9 +57,9 @@ const EXPLOITATION_DB_COLLECTION_NAMES = {
 const commonToponymPageQuery = `
   SELECT
     CT.id, CT."districtID", CT.labels, CT.geometry, CT."updateDate", CT.meta, CT."createdAt", CT."updatedAt",
-    ST_Centroid(ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON((A.positions[1])->'geometry'), 4326))) AS centroid,
-    ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON((A.positions[1])->'geometry'), 4326))), 2154), :addressBboxBuffer, 'join=mitre endcap=square'), 4326) AS "addressBbox",
-    ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_SetSRID(ST_GeomFromGeoJSON(CT.geometry), 4326)), 2154), :bboxBuffer, 'join=mitre endcap=square'), 4326) AS "bbox",
+    ST_Centroid(ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON((A.positions[1])->'geometry')::text, 4326))) AS centroid,
+    ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON((A.positions[1])->'geometry')::text, 4326))), 2154), :addressBboxBuffer, 'join=mitre endcap=square'), 4326) AS "addressBbox",
+    ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_SetSRID(ST_GeomFromGeoJSON(CT.geometry)::text, 4326)), 2154), :bboxBuffer, 'join=mitre endcap=square'), 4326) AS "bbox",
     COUNT(A.id) AS "addressCount",
     COUNT(DISTINCT CASE WHEN a.certified = true THEN a.id ELSE NULL END) AS "certifiedAddressCount"
   FROM
@@ -83,7 +83,7 @@ const commonToponymPageQuery = `
 const addressPageQuery = `
   SELECT
     A.*,
-    ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_SetSRID(ST_GeomFromGeoJSON((A.positions[1])->'geometry'), 4326)), 2154), :bboxBuffer, 'join=mitre endcap=square'), 4326) AS bbox
+    ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_SetSRID(ST_GeomFromGeoJSON((A.positions[1])->'geometry')::text, 4326)), 2154), :bboxBuffer, 'join=mitre endcap=square'), 4326) AS bbox
   FROM
     "Addresses" AS A
   WHERE A."districtID" = :districtID


### PR DESCRIPTION
# Context 

We are currently in a late version of postgis (2.4) that does not recognize jsonb.

# Enhancement

As a quick fix, this PR converts the jsonb to text.
This is a temporary fix before the postgresql and postgis version upgrade