### PR TITLE
Added postgres port env variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,7 +5,7 @@ MONGODB_DBNAME=ban
 
 # Postgres DB
 POSTGRES_URL=localhost # Not used for deployment with Docker Compose
-POSTGRES_PORT=5432 # Used only for deployment with Docker Compose
+POSTGRES_PORT=5432
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DBNAME=ban

--- a/lib/util/sequelize.js
+++ b/lib/util/sequelize.js
@@ -1,8 +1,11 @@
 import {Sequelize, DataTypes} from 'sequelize'
 
+const POSTGRES_PORT = process.env.POSTGRES_PORT || 5432
+
 // Create a new Sequelize instance
 export const sequelize = new Sequelize(process.env.POSTGRES_DBNAME, process.env.POSTGRES_USER, process.env.POSTGRES_PASSWORD, {
   host: process.env.POSTGRES_URL,
+  port: POSTGRES_PORT,
   dialect: 'postgres',
   logging: false
 })


### PR DESCRIPTION
# Context

In order to make a progressive infrastructure evolution of the postgresDB, We need to be able to set the postgresql db access port easily.

# Enhancement

This PR adds the possibility to set the postgresql port through an env variable : 
- POSTGRES_PORT = ... (the desired port)

# TO-DO before going to production 

- add a POSTGRES_PORT env variable to the .env file in production (it will work without it because we have set a default value in the code if the variable is empty).