### PR TITLE
Added 4 concurrency processes to legacy compose

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -27,7 +27,7 @@ async function main() {
   }
 
   // Legacy
-  queue('compose-commune').process(2, composeCommune)
+  queue('compose-commune').process(4, composeCommune)
   queue('compute-ban-stats').process(1, computeBanStats)
   queue('compute-ban-stats').add({}, {jobId: 'computeBanStatsJobId', repeat: {every: ms('15m')}, removeOnComplete: true})
 


### PR DESCRIPTION
# Context

To fix concurrency issues on new API (consumers can consume jobs in an order different than the order of the api calls), we are going to set pm2 to start only one worker.js process (modifying ecosystem.json)

# Enhancement

In order to improve concurrency on the legacy "compose" this PR aims to switch concurrency number from 2 to 4 (everything will run on one node process). 