### PR TITLE
Added version query param to download csv api route

### DIFF
--- a/lib/api/legacy-routes.cjs
+++ b/lib/api/legacy-routes.cjs
@@ -203,19 +203,30 @@ app.param(
   })
 )
 
+const acceptedBalVersion = new Set(['1.3', '1.4'])
+
 // API Download Commune Data
 app.get(
   '/ban/communes/:codeCommune/download/:downloadFormat/:downloadType',
   analyticsMiddleware.downloadCommuneData,
   w(async (req, res) => {
     const {codeCommune, downloadFormat, downloadType} = req.params
+    const {version = '1.3'} = req.query
+    const isCsvBal = downloadFormat === 'csv-bal'
+    if (isCsvBal && version && !acceptedBalVersion.has(version)) {
+      return res.status(404).send({
+        code: 404,
+        message: 'La version demandée n’est pas disponible',
+      })
+    }
+
     const {voies, numeros} = await getCommuneData(codeCommune)
 
     const data = prepareMethode
       ?.[downloadFormat]
-      ?.[downloadType]?.({voies, numeros}, true) || null
+      ?.[downloadType]?.({voies, numeros}, {includesAlt: true, version}) || null
 
-    const headers = downloadFormat === 'csv-bal'
+    const headers = isCsvBal
       ? {
         header: true,
         columns: extractHeaders(data),

--- a/lib/formatters/csv-bal.cjs
+++ b/lib/formatters/csv-bal.cjs
@@ -48,10 +48,23 @@ function buildBalUIDAdresse(numero) {
   }, '')
 }
 
-function buildRow(voie, numero, position, includesAlt = false) {
-  const uid_adresse = buildBalUIDAdresse(numero)
+function buildBalIDs(numero, version) {
+  switch (version) {
+    case '1.4':
+      return {
+        id_ban_commune: numero.banIdDistrict || '',
+        id_ban_toponyme: numero.banIdMainCommonToponym || '',
+        id_ban_adresse: numero.banId || '',
+      }
+    default:
+      return {uid_adresse: buildBalUIDAdresse(numero)}
+  }
+}
+
+function buildRow(voie, numero, position, {includesAlt = false, version = '1.3'}) {
+  console.log('version', version)
   const row = {
-    uid_adresse,
+    ...buildBalIDs(numero, version),
     cle_interop: numero.cleInterop,
     commune_insee: voie.codeCommune,
     commune_nom: voie.nomCommune,
@@ -111,7 +124,7 @@ function createFakeNumero(voie) {
   }
 }
 
-function prepareAdresses({voies, numeros}, includesAlt) {
+function prepareAdresses({voies, numeros}, {includesAlt, version}) {
   const numerosIndex = groupBy(numeros, 'idVoie')
   const rows = []
 
@@ -119,12 +132,12 @@ function prepareAdresses({voies, numeros}, includesAlt) {
     if (voie.type === 'lieu-dit') {
       const fakeNumero = createFakeNumero(voie)
       const position = voie.position ? {position: voie.position} : null
-      rows.push(buildRow(voie, fakeNumero, position, includesAlt))
+      rows.push(buildRow(voie, fakeNumero, position, {includesAlt, version}))
     } else if (voie.type === 'voie') {
       const numerosVoie = numerosIndex[voie.idVoie] || []
       for (const numero of numerosVoie) {
         for (const position of numero.positions) {
-          rows.push(buildRow(voie, numero, position, includesAlt))
+          rows.push(buildRow(voie, numero, position, {includesAlt, version}))
         }
       }
     }


### PR DESCRIPTION
# Context

Currently, using ban-plateforme API, we can download a district BAL from BAN DB as csv file ONLY in version 1.3. The adresse.data.gouv website is using the api on the "commune" page : 

 
<img width="1458" alt="Capture d’écran 2024-01-23 à 15 34 09" src="https://github.com/BaseAdresseNationale/ban-plateforme/assets/52679050/668e7be1-4b44-45e6-a92c-31e285d5fe5e">

To be able to dowload new 1.4 BAL version, we need to adapt the current behavior, starting by the API : 

`/ban/communes/:codeCommune/download/:downloadFormat/:downloadType`

# Enhancement

This PR aims to enhanced the current download API by : 
- adding a new query parameter : "version" (that only accepts '1.3' and '1.4' values)

If the query parameter is not set (as it is currently on the website), the version 1.3 is set by default

# How to test

- Pre-requisite : Have at least one district data in the BAN mongo DB
- Using Postman (or similar), call the following routes : 
GET http://localhost:${your_port}/ban/communes/${your_commune}/download/csv-bal/adresses?version=1.3
GET http://localhost:${your_port}/ban/communes/${your_commune}/download/csv-bal/adresses?version=1.4

Replace : 
- ${your_port} by the port your ban-plateforme app is running on
- ${your_commune} by the insee code of a commune you have locally in your mongodb