### PR TITLE
fix dist

### DIFF
--- a/lib/formatters/csv-bal.cjs
+++ b/lib/formatters/csv-bal.cjs
@@ -124,7 +124,7 @@ function createFakeNumero(voie) {
   }
 }
 
-function prepareAdresses({voies, numeros}, {includesAlt, version}) {
+function prepareAdresses({voies, numeros}, {includesAlt, version} = {}) {
   const numerosIndex = groupBy(numeros, 'idVoie')
   const rows = []
 

--- a/lib/formatters/csv-bal.cjs
+++ b/lib/formatters/csv-bal.cjs
@@ -62,7 +62,6 @@ function buildBalIDs(numero, version) {
 }
 
 function buildRow(voie, numero, position, {includesAlt = false, version = '1.3'}) {
-  console.log('version', version)
   const row = {
     ...buildBalIDs(numero, version),
     cle_interop: numero.cleInterop,


### PR DESCRIPTION
# Context

"dist" script is broken because prepareAdresses function new options variable didn't have a default value.

# Enhancement 

This PR aims to fix the issue by adding : 
- a default value`{}` to `options` parameter