### PR TITLE
Change postal code calculation

### DIFF
--- a/db-migrations/migrations/20240131133110-init-views.js
+++ b/db-migrations/migrations/20240131133110-init-views.js
@@ -1,0 +1,242 @@
+'use strict'
+
+require('dotenv').config()
+
+const {POSTGRES_BAN_USER} = process.env
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    try {
+      // Create external schema if not exists
+      await queryInterface.sequelize.query('CREATE SCHEMA IF NOT EXISTS external;')
+      // Grant permissions to ban user on schema external
+      await queryInterface.sequelize.query(`GRANT USAGE ON SCHEMA external TO ${POSTGRES_BAN_USER};`)
+
+      // Create contours_postaux Table if not exists
+      await queryInterface.createTable('contours_postaux', {
+        codePostal: {
+          type: Sequelize.STRING,
+          allowNull: false,
+        },
+        cog: {
+          type: Sequelize.STRING,
+          allowNull: false,
+        },
+        geometry: {
+          type: Sequelize.JSONB,
+          allowNull: false,
+        },
+      }, {
+        schema: 'external',
+        ifNotExists: true,
+      })
+
+      // Grant permissions to ban user
+      await queryInterface.sequelize.query(`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA external TO ${POSTGRES_BAN_USER};`)
+
+      // Create Address with meta View
+      await queryInterface.sequelize.query(`
+        CREATE OR REPLACE VIEW ban.address_with_meta AS
+          WITH banMeta AS (
+            SELECT
+              a.id,
+              ST_AsGeoJSON(ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_SetSRID(ST_GeomFromGeoJSON((a.positions[1])->'geometry'), 4326)), 2154), 50, 'join=mitre endcap=square'), 4326)) AS bbox
+            FROM ban.address AS a
+          ),
+          inseeMeta AS (
+            SELECT
+              a.id,
+              d.meta->'insee'->>'cog' AS cog
+            FROM ban.address AS a
+            LEFT JOIN ban.district AS d
+            ON a."districtID" = d.id
+          ),
+          laPosteMeta AS (
+            SELECT
+              a.id,
+              d.meta->'laPoste'->>'libelleAcheminement' AS libelleAcheminement,
+              CASE JSONB_ARRAY_LENGTH(d.meta->'laPoste'->'codePostal')
+                WHEN '1' THEN (d.meta->'laPoste'->'codePostal')[0]::text
+                  ELSE
+                    COALESCE(
+                      cp."codePostal",
+                      (
+                        SELECT cp2."codePostal"
+                        FROM external.contours_postaux AS cp2
+                        WHERE (d.meta->'insee')->> 'cog' LIKE cp2.cog
+                        ORDER BY ST_Distance(
+                          ST_GeomFromGeoJSON((a.positions[1])->'geometry'),
+                          cp2.geometry)
+                        LIMIT 1
+                      )
+                    )
+              END
+              AS codePostal,
+              CASE JSONB_ARRAY_LENGTH(d.meta->'laPoste'->'codePostal')
+                WHEN '1' THEN 'La Poste - dataNOVA'
+              END
+              AS source
+            FROM ban.address AS a
+            LEFT JOIN ban.district AS d
+            ON a."districtID" = d.id
+            LEFT JOIN external.contours_postaux AS cp
+            ON (d.meta->'insee')->> 'cog' LIKE cp.cog AND ST_Within(ST_GeomFromGeoJSON((a.positions[1])->'geometry'), cp.geometry)
+          )
+          SELECT
+            a.id,
+            a."districtID",
+            a."mainCommonToponymID",
+            a."secondaryCommonToponymIDs",
+            a.labels,
+            a.number,
+            a.suffix,
+            a.positions,
+            a.certified,
+            COALESCE(
+              a.meta,
+              jsonb ('{}')
+            ) ||
+            COALESCE(
+              jsonb('{"ban": {"bbox": ' || banMeta.bbox::text || '}}'),
+              jsonb('{}')
+            ) ||
+            COALESCE(
+              jsonb('{"insee": {"cog": "' || inseeMeta.cog || '"}}'),
+              jsonb('{}')
+            ) ||
+            CASE 
+              WHEN laPosteMeta.codePostal IS NOT NULL AND laPosteMeta.source IS NOT NULL
+              THEN COALESCE(
+                jsonb('{"laPoste": {"codePostal": "' || laPosteMeta.codePostal || '", "source": "' || laPosteMeta.source || '", "libelleAcheminement": "' || laPosteMeta.libelleAcheminement || '"}}'),
+                jsonb('{"laPoste": {"codePostal": "' || laPosteMeta.codePostal || '", "source": "' || laPosteMeta.source || '"}}')
+              )
+              WHEN laPosteMeta.codePostal IS NOT NULL
+              THEN COALESCE(
+                jsonb('{"laPoste": {"codePostal": "' || laPosteMeta.codePostal || '", "source": "La Poste - contours postaux", "libelleAcheminement": "' || laPosteMeta.libelleAcheminement || '"}}'),
+                jsonb('{"laPoste": {"codePostal": "' || laPosteMeta.codePostal || '", "source": "La Poste - contours postaux"}}')
+              )
+              ELSE COALESCE(
+                jsonb('{"laPoste": {"libelleAcheminement": "' || laPosteMeta.libelleAcheminement || '"}}'),
+                jsonb('{}')
+              )
+            END
+            AS meta,
+            a."updateDate"
+          FROM ban.address AS a
+          LEFT JOIN banMeta
+          ON a.id = banMeta.id
+          LEFT JOIN inseeMeta
+          ON a.id = inseeMeta.id
+          LEFT JOIN laPosteMeta
+          ON a.id = laPosteMeta.id
+      `)
+
+      // Create Common Toponym with meta View
+      await queryInterface.sequelize.query(`
+        CREATE OR REPLACE VIEW ban.common_toponym_with_meta AS
+          WITH banMeta AS (
+            SELECT
+              ct.id,
+              ST_AsGeoJSON(ST_Centroid(ST_Collect(ST_GeomFromGeoJSON(a.positions[1] ->> 'geometry')))) AS centroid,
+              ST_AsGeoJSON(ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON(a.positions[1] ->> 'geometry'), 4326))), 2154), 200, 'join=mitre endcap=square'), 4326)) AS addressBbox,
+              ST_AsGeoJSON(ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_SetSRID(ST_GeomFromGeoJSON(ct.geometry), 4326)), 2154), 100, 'join=mitre endcap=square'), 4326)) AS bbox
+            FROM ban.common_toponym AS ct
+            LEFT JOIN ban.address_with_meta AS a
+            ON ct.id = a."mainCommonToponymID" OR ct.id = ANY (a."secondaryCommonToponymIDs")
+            GROUP BY ct.id
+          ),
+          inseeMeta AS (
+            SELECT
+              ct.id,
+              d.meta -> 'insee' ->> 'cog' AS cog
+            FROM ban.common_toponym AS ct
+            LEFT JOIN ban.district AS d
+            ON ct."districtID" = d.id
+            ),
+            laPosteMeta AS (
+              SELECT
+                ct.id,
+                d.meta -> 'laPoste' ->> 'libelleAcheminement' AS libelleAcheminement,
+                array_agg(DISTINCT '"' || (a.meta -> 'laPoste' ->> 'codePostal') || '"') AS codePostal,
+                a.meta -> 'laPoste' ->> 'source' AS source
+              FROM ban.common_toponym AS ct
+              LEFT JOIN ban.district AS d
+              ON ct."districtID" = d.id
+              LEFT JOIN ban.address_with_meta AS a
+              ON (ct.id = a."mainCommonToponymID" OR ct.id = ANY (a."secondaryCommonToponymIDs")) AND (a.meta -> 'laPoste' ->> 'codePostal') IS NOT NULL
+              GROUP BY 
+                ct.id,
+                d.meta,
+                (a.meta -> 'laPoste' ->> 'source')
+            )
+          SELECT
+            ct.id,
+            ct."districtID",
+            ct.labels,
+            ct.geometry,
+            COALESCE(
+              ct.meta,
+              jsonb('{}')
+            ) ||
+            CASE
+              WHEN banMeta.centroid IS NOT NULL
+              THEN jsonb(
+                '{"ban": {"centroid": ' || banMeta.centroid || ', "addressBbox": ' || banMeta.addressBbox ||
+                COALESCE(
+                  (', "bbox": ' || banMeta.bbox) || '}}',
+                  '}}'
+                  )
+                )
+              ELSE COALESCE(
+                jsonb('{"ban": {"bbox": ' || banMeta.bbox || '}}'),
+                jsonb('{}')
+              )
+            END ||
+            COALESCE(
+              jsonb('{"insee": {"cog": "' || inseeMeta.cog || '"}}'),
+              jsonb('{}')
+            ) ||
+            CASE 
+              WHEN laPosteMeta.codePostal[1] IS NOT NULL
+              THEN jsonb(
+                '{"laPoste": {"codePostal": ' ||
+                replace(replace(laPosteMeta.codePostal::text, '{', '['), '}', ']') ||
+                ', "source": "' || laPosteMeta.source ||
+                COALESCE(
+                  '", "libelleAcheminement": "' || laPosteMeta.libelleAcheminement || '"}}',
+                  '"}}'
+                )
+              )
+              ELSE COALESCE(
+                jsonb('{"laPoste": {"libelleAcheminement": "' || laPosteMeta.libelleAcheminement || '"}}'),
+                jsonb('{}')
+              )
+            END
+            AS meta,
+            ct."updateDate"
+          FROM ban.common_toponym AS ct
+          LEFT JOIN ban.district AS d
+          ON d.id = ct."districtID"
+          LEFT JOIN banMeta ON ct.id = banMeta.id
+          LEFT JOIN inseeMeta ON ct.id = inseeMeta.id
+          LEFT JOIN laPosteMeta ON ct.id = laPosteMeta.id
+      `)
+      // Grant permissions to ban user
+      await queryInterface.sequelize.query(`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL VIEWS IN SCHEMA ban TO ${POSTGRES_BAN_USER};`)
+    } catch (error) {
+      console.error(error)
+    }
+  },
+
+  async down(queryInterface) {
+    try {
+      await queryInterface.sequelize.query('DROP VIEW IF EXISTS ban.common_toponym_with_meta CASCADE;')
+      await queryInterface.sequelize.query('DROP VIEW IF EXISTS ban.address_with_meta CASCADE;')
+      await queryInterface.sequelize.query('DROP TABLE IF EXISTS external.contours_postaux CASCADE;')
+      await queryInterface.sequelize.query('DROP SCHEMA IF EXISTS external;')
+    } catch (error) {
+      console.error(error)
+    }
+  }
+}

--- a/lib/api/consumers/api-consumer.js
+++ b/lib/api/consumers/api-consumer.js
@@ -5,7 +5,7 @@ import {checkAddressesRequest, checkAddressesIDsRequest} from '../address/utils.
 import {setCommonToponyms, updateCommonToponyms, patchCommonToponyms, deleteCommonToponyms, getAllDistrictIDsFromCommonToponyms} from '../common-toponym/models.js'
 import {checkCommonToponymsRequest, checkCommonToponymsIDsRequest} from '../common-toponym/utils.js'
 import {setDistricts, updateDistricts, patchDistricts, deleteDistricts} from '../district/models.js'
-import {checkDistrictsRequest, checkDistrictsIDsRequest} from '../district/utils.js'
+import {checkDistrictsRequest, checkDistrictsIDsRequest, formatDataNova} from '../district/utils.js'
 import {dataValidationReportFrom, formatObjectWithDefaults, addOrUpdateJob, formatPayloadDates} from '../helper.js'
 import {addressDefaultOptionalValues} from '../address/schema.js'
 import {commonToponymDefaultOptionalValues} from '../common-toponym/schema.js'
@@ -216,6 +216,8 @@ const districtConsumer = async (jobType, payload, statusID) => {
         return checkDistrictsRequest(payload, jobType)
       case 'delete':
         return checkDistrictsIDsRequest(payload, jobType)
+      case 'updatePostalCode':
+        return dataValidationReportFrom(true)
       default:
         return dataValidationReportFrom(false, 'Unknown action type', {actionType: jobType, payload})
     }
@@ -229,6 +231,8 @@ const districtConsumer = async (jobType, payload, statusID) => {
         return formatPayloadDates(payload, jobType)
       case 'delete':
         return payload
+      case 'updatePostalCode':
+        return formatDataNova(payload)
       default:
         console.warn(`District Consumer Warn: Unknown job type : '${jobType}'`)
     }
@@ -255,6 +259,7 @@ const districtConsumer = async (jobType, payload, statusID) => {
       }
 
       case 'patch':
+      case 'updatePostalCode':
         await patchDistricts(formattedPayload)
         break
       case 'delete':

--- a/lib/api/consumers/export-to-exploitation-db-consumer.js
+++ b/lib/api/consumers/export-to-exploitation-db-consumer.js
@@ -28,12 +28,6 @@ const TILES_ZOOM_LEVELS = {
   }
 }
 
-// The buffer distance to use for the bbox calculation
-const COMMON_TOPONYM_BBOX_BUFFER = 200
-// For specific common toponyms (='lieu-dit'), we use a different buffer distance
-const SPECIFIC_COMMON_TOPONYM_BBOX_BUFFER = 100
-const ADDRESS_BBOX_BUFFER = 50
-
 // Collections names
 const EXPLOITATION_DB_COLLECTION_NAMES = {
   legacy: {
@@ -55,23 +49,9 @@ const EXPLOITATION_DB_COLLECTION_NAMES = {
 // The bbox result is transformed to a different coordinate system (2154 to 4326) and includes a buffer operation.
 
 const commonToponymPageQuery = `
-  SELECT
-    CT.id, CT."districtID", CT.labels, CT.geometry, CT."updateDate", CT.meta, CT."createdAt", CT."updatedAt",
-    ST_Centroid(ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON((A.positions[1])->'geometry'), 4326))) AS centroid,
-    ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_Collect(ST_SetSRID(ST_GeomFromGeoJSON((A.positions[1])->'geometry'), 4326))), 2154), :addressBboxBuffer, 'join=mitre endcap=square'), 4326) AS "addressBbox",
-    ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_SetSRID(ST_GeomFromGeoJSON(CT.geometry), 4326)), 2154), :bboxBuffer, 'join=mitre endcap=square'), 4326) AS "bbox",
-    COUNT(A.id) AS "addressCount",
-    COUNT(DISTINCT CASE WHEN a.certified = true THEN a.id ELSE NULL END) AS "certifiedAddressCount"
-  FROM
-    ban.common_toponym AS CT
-  LEFT JOIN
-    ban.address AS A
-  ON
-    CT.id = A."mainCommonToponymID"
-    OR CT.id = ANY(A."secondaryCommonToponymIDs")
-  WHERE CT."districtID" = :districtID
-  GROUP BY CT.id
-  ORDER BY CT.id ASC
+  SELECT * FROM ban.common_toponym_with_meta
+  WHERE "districtID" = :districtID
+  ORDER BY id ASC
   OFFSET :offset
   LIMIT :limit
 `
@@ -81,13 +61,9 @@ const commonToponymPageQuery = `
 // The result is transformed from one coordinate system (2154) to another (4326)
 // and includes a buffer operation with a distance of 50 units and specific parameters for joining and capping.
 const addressPageQuery = `
-  SELECT
-    A.*,
-    ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_SetSRID(ST_GeomFromGeoJSON((A.positions[1])->'geometry'), 4326)), 2154), :bboxBuffer, 'join=mitre endcap=square'), 4326) AS bbox
-  FROM
-    ban.address AS A
-  WHERE A."districtID" = :districtID
-  ORDER BY A.id ASC
+  SELECT * FROM ban.address_with_meta
+  WHERE "districtID" = :districtID
+  ORDER BY id ASC
   OFFSET :offset
   LIMIT :limit
 `
@@ -149,20 +125,17 @@ export default async function exportToExploitationDB({data}) {
         replacements: {
           districtID,
           offset,
-          limit: PAGE_SIZE,
-          addressBboxBuffer: COMMON_TOPONYM_BBOX_BUFFER,
-          bboxBuffer: SPECIFIC_COMMON_TOPONYM_BBOX_BUFFER},
+          limit: PAGE_SIZE},
         transaction,
         raw: true,
       })
       // Format the data and calculate the fantoir code, tiles and postal code
       const pageDataWithExtraDataCalculation = pageData.map(commonToponym => calculateExtraDataForCommonToponym(commonToponym, cog, fantoirFinder, commonToponymIDFantoirCodeMap))
-      const formatedPageData = pageDataWithExtraDataCalculation.map(commonToponym => formatCommonToponym(commonToponym))
       const formatedPageDataForLegacy = pageDataWithExtraDataCalculation.map(commonToponym => formatCommonToponymDataForLegacy(commonToponym, district, pseudoCodeVoieGenerator, commonToponymIDlegacyCommonToponymIDMap))
 
       // Insert the data in the collection (legacy and banID)
       await mongo.db.collection(EXPLOITATION_DB_COLLECTION_NAMES.legacy.commonToponym).insertMany(formatedPageDataForLegacy, {ordered: false})
-      await mongo.db.collection(EXPLOITATION_DB_COLLECTION_NAMES.banID.commonToponym).insertMany(formatedPageData, {ordered: false})
+      await mongo.db.collection(EXPLOITATION_DB_COLLECTION_NAMES.banID.commonToponym).insertMany(pageDataWithExtraDataCalculation, {ordered: false})
     }
 
     const commonToponymsExportPromises = []
@@ -186,8 +159,7 @@ export default async function exportToExploitationDB({data}) {
         replacements: {
           districtID,
           offset,
-          limit: PAGE_SIZE,
-          bboxBuffer: ADDRESS_BBOX_BUFFER},
+          limit: PAGE_SIZE},
         transaction,
         raw: true,
       })
@@ -270,7 +242,14 @@ export const calculateExtraDataForCommonToponym = (commonToponym, cog, fantoirFi
   // Calculate the tiles for each common toponym
   const {geometry, tiles, x, y} = calculateCommonToponymGeometryAndTiles(commonToponym)
   // Calculate the postal code for each common toponym
-  const {codePostal: postalCode, libelleAcheminement: deliveryLabel} = calculateCommonToponymPostalCode(commonToponymIDFantoirCodeMap, commonToponym, cog)
+  let postalCodeFromFIMOCT
+  let deliveryLabelFromFIMOCT
+  if (!commonToponym.meta?.laPoste?.codePostal) {
+    const result = calculateCommonToponymPostalCode(commonToponymIDFantoirCodeMap, commonToponym, cog)
+    postalCodeFromFIMOCT = result?.codePostal
+    deliveryLabelFromFIMOCT = result?.libelleAcheminement
+  }
+
   // Remove the centroid data from the common toponym
   return {...commonToponym,
     geometry,
@@ -278,7 +257,7 @@ export const calculateExtraDataForCommonToponym = (commonToponym, cog, fantoirFi
       ...commonToponym.meta,
       ...(fantoirCode ? {dgfip: {...commonToponym.meta?.dgfip, fantoir: fantoirCode}} : {}),
       ...(tiles && x && y ? {geography: {...commonToponym.meta?.geography, tiles, x, y}} : {}),
-      ...(postalCode && deliveryLabel ? {laposte: {...commonToponym.meta?.laposte, codePostal: postalCode, libelleAcheminement: deliveryLabel}} : {})
+      ...(!commonToponym.meta?.laPoste?.codePostal && postalCodeFromFIMOCT && deliveryLabelFromFIMOCT ? {laPoste: {...commonToponym.meta?.laPoste, codePostal: postalCodeFromFIMOCT, libelleAcheminement: deliveryLabelFromFIMOCT, source: 'DGFIP - FIMOCT'}} : {})
     }}
 }
 
@@ -286,12 +265,19 @@ export const calculateExtraDataForAddress = (address, cog, commonToponymIDFantoi
   // Calculate the tiles for each address
   const {tiles, x, y} = calculateAddressTiles(address)
   // Calculate the postal code for each address
-  const {codePostal: postalCode, libelleAcheminement: deliveryLabel} = calculateAddressPostalCode(commonToponymIDFantoirCodeMap, address, cog)
+  let postalCode
+  let deliveryLabel
+  if (!address.meta?.laPoste?.codePostal) {
+    const result = calculateAddressPostalCode(commonToponymIDFantoirCodeMap, address, cog)
+    postalCode = result?.codePostal
+    deliveryLabel = result?.libelleAcheminement
+  }
+
   return {...address,
     meta: {
       ...address.meta,
       ...(tiles && x && y ? {geography: {...address.meta?.geography, tiles, x, y}} : {}),
-      ...(postalCode && deliveryLabel ? {laposte: {...address.meta?.laposte, codePostal: postalCode, libelleAcheminement: deliveryLabel}} : {})
+      ...(!address.meta?.laPoste?.codePostal && postalCode && deliveryLabel ? {laPoste: {...address.meta?.laPoste, codePostal: postalCode, libelleAcheminement: deliveryLabel, source: 'DGFIP - FIMOCT'}} : {})
     }
   }
 }
@@ -340,7 +326,8 @@ const calculateAddressPostalCode = (commonToponymIDFantoirCodeMap, address, cog)
 
 // Helpers to calculate the tiles
 const calculateCommonToponymGeometryAndTiles = commonToponym => {
-  const {geometry: geometryFromCommonToponym, centroid} = commonToponym
+  const geometryFromCommonToponym = commonToponym?.geometry
+  const centroid = commonToponym?.meta?.ban?.centroid
   let geometryFromCentroid
   if (centroid) {
     geometryFromCentroid = {

--- a/lib/api/consumers/format-to-legacy-helpers.js
+++ b/lib/api/consumers/format-to-legacy-helpers.js
@@ -89,7 +89,7 @@ export const formatDistrictDataForLegacy = async (district, totalCommonToponymRe
 
 export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudoCodeVoieGenerator, commonToponymIDlegacyCommonToponymIDMap) => {
   const {labels: districtLabels, meta: {insee: {cog}}} = district
-  const {id, districtID, geometry, labels, meta, updateDate, addressCount, certifiedAddressCount, bbox, addressBbox} = commonToponym
+  const {id, districtID, geometry, labels, meta, updateDate} = commonToponym
 
   // Labels
   // District
@@ -118,8 +118,8 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
   }
   const lon = legacyPosition?.coordinates?.[0]
   const lat = legacyPosition?.coordinates?.[1]
-  const commonToponymBbox = formatBboxForLegacy(bbox)
-  const commonToponymAddressBbox = formatBboxForLegacy(addressBbox)
+  const commonToponymBbox = formatBboxForLegacy(meta?.ban?.bbox)
+  const commonToponymAddressBbox = formatBboxForLegacy(meta?.ban?.addressBbox)
 
   const isLieuDit = meta?.bal?.isLieuDit
 
@@ -138,13 +138,13 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
       nomCommune: districtLegacyLabelValue,
       codeAncienneCommune,
       nomAncienneCommune: meta?.bal?.nomAncienneCommune,
-      codePostal: meta?.laposte?.codePostal,
+      codePostal: meta?.laPoste?.codePostal,
       parcelles: meta?.cadastre?.ids || [],
       lon,
       lat,
-      x: meta?.geography?.x,
-      y: meta?.geography?.y,
-      tiles: meta?.geography?.tiles,
+      x: meta?.ban?.x,
+      y: meta?.ban?.y,
+      tiles: meta?.ban?.tiles,
       position: legacyPosition,
       displayBBox: commonToponymBbox,
       dateMAJ: legacyUpdateDate
@@ -165,7 +165,7 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
     nomVoieAlt: legacyComplementaryLabels,
     sourceNomVoie: 'bal',
     position: legacyPosition,
-    codePostal: meta?.laposte?.codePostal,
+    codePostal: meta?.laPoste?.codePostal,
     displayBBox: commonToponymAddressBbox,
     lon,
     lat,
@@ -173,14 +173,14 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
     y: meta?.geography?.y,
     tiles: meta?.geography?.tiles,
     sources: ['bal'],
-    nbNumeros: Number.parseInt(addressCount, 10),
-    nbNumerosCertifies: Number.parseInt(certifiedAddressCount, 10)
+    nbNumeros: Number.parseInt(meta?.ban?.addressCount, 10),
+    nbNumerosCertifies: Number.parseInt(meta?.ban?.certifiedAddressCount, 10)
   }
 }
 
 export const formatAddressDataForLegacy = (address, district, commonToponymIDlegacyCommonToponymIDMap) => {
   const {meta: {insee: {cog}}} = district
-  const {id, mainCommonToponymID, secondaryCommonToponymIDs, districtID, number, suffix, positions, labels, meta, updateDate, certified, bbox} = address
+  const {id, mainCommonToponymID, secondaryCommonToponymIDs, districtID, number, suffix, positions, labels, meta, updateDate, certified} = address
 
   // Labels
   const defaultLabel = getDefaultLabel(labels)
@@ -196,7 +196,7 @@ export const formatAddressDataForLegacy = (address, district, commonToponymIDleg
   const legacyPosition = legacyPositions?.[0]?.position
   const legacyPositionType = legacyPositions?.[0]?.positionType
   const [lon, lat] = formatLegacyLonLat(legacyPosition)
-  const addressBbox = formatBboxForLegacy(bbox)
+  const addressBbox = formatBboxForLegacy(meta?.ban?.bbox)
 
   // Ids
   const legacyCommonToponymId = commonToponymIDlegacyCommonToponymIDMap.get(mainCommonToponymID)
@@ -234,7 +234,7 @@ export const formatAddressDataForLegacy = (address, district, commonToponymIDleg
     sourcePosition: 'bal',
     dateMAJ: legacyUpdateDate,
     certifie: certified,
-    codePostal: meta?.laposte?.codePostal,
+    codePostal: meta?.laPoste?.codePostal,
     libelleAcheminement: meta?.laposte?.libelleAcheminement,
     adressesOriginales: [address]
   }

--- a/lib/api/district/__mocks__/district-models.js
+++ b/lib/api/district/__mocks__/district-models.js
@@ -3,3 +3,10 @@ import {bddDistrictMock} from './district-data-mock.js'
 export async function getDistricts(districtIDs) {
   return bddDistrictMock.filter(({id}) => districtIDs.includes(id))
 }
+
+export async function getDistrictsFromCog(districtCOGs) {
+  return bddDistrictMock
+    .map(district => [district.meta.insee.cog, district])
+    .filter(([cog]) => districtCOGs.includes(cog))
+    .map(([, district]) => district)
+}

--- a/lib/api/district/models.js
+++ b/lib/api/district/models.js
@@ -1,10 +1,24 @@
+import {Op} from 'sequelize'
 import {District} from '../../util/sequelize.js'
 
 export const getDistrict = districtID => District.findByPk(districtID, {raw: true})
 
 export const getDistricts = districtIDs => District.findAll({where: {id: districtIDs}, raw: true})
 
-export const getDistrictsFromCog = cog => District.findAll({where: {meta: {insee: {cog}}}, raw: true})
+export const getDistrictFromCog = cog => District.findAll({where: {meta: {insee: {cog}}}, raw: true})
+
+export const getDistrictsFromCog = async cog => {
+  const districts = await District.findAll({where: {meta: {insee: {cog: {[Op.or]: cog}}}}, raw: true})
+  const districtsByInseeCode = districts.reduce(
+    (acc, district) => {
+      if (!acc[district.meta?.insee?.cog]) {
+        acc[district.meta.insee.cog] = district
+      }
+
+      return acc
+    }, {})
+  return cog.map(codeInsee => districtsByInseeCode[codeInsee] || {})
+}
 
 export const setDistricts = districts => District.bulkCreate(districts)
 

--- a/lib/api/district/models.js
+++ b/lib/api/district/models.js
@@ -7,8 +7,8 @@ export const getDistricts = districtIDs => District.findAll({where: {id: distric
 
 export const getDistrictFromCog = cog => District.findAll({where: {meta: {insee: {cog}}}, raw: true})
 
-export const getDistrictsFromCog = async cog => {
-  const districts = await District.findAll({where: {meta: {insee: {cog: {[Op.or]: cog}}}}, raw: true})
+export const getDistrictsFromCog = async cogList => {
+  const districts = await District.findAll({where: {meta: {insee: {cog: {[Op.or]: cogList}}}}, raw: true})
   const districtsByInseeCode = districts.reduce(
     (acc, district) => {
       if (!acc[district.meta?.insee?.cog]) {
@@ -17,7 +17,7 @@ export const getDistrictsFromCog = async cog => {
 
       return acc
     }, {})
-  return cog.map(codeInsee => districtsByInseeCode[codeInsee] || {})
+  return cogList.map(codeInsee => districtsByInseeCode[codeInsee] || {})
 }
 
 export const setDistricts = districts => District.bulkCreate(districts)

--- a/lib/api/district/routes.js
+++ b/lib/api/district/routes.js
@@ -1,12 +1,11 @@
 import 'dotenv/config.js' // eslint-disable-line import/no-unassigned-import
 import {customAlphabet} from 'nanoid'
 import express from 'express'
-import Papa from 'papaparse'
 import queue from '../../util/queue.cjs'
 import auth from '../../middleware/auth.js'
 import analyticsMiddleware from '../../middleware/analytics.js'
 import fetch from '../../util/fetch.cjs'
-import {getDistrict, getDistrictFromCog, getDistrictsFromCog, deleteDistrict, patchDistricts} from './models.js'
+import {getDistrict, getDistrictFromCog, deleteDistrict} from './models.js'
 
 const apiQueue = queue('api')
 
@@ -217,70 +216,6 @@ app.get('/cog/:cog', analyticsMiddleware, async (req, res) => {
   res.send(response)
 })
 
-async function updateDbFromDataNova(postalFile) {
-  /* eslint-disable camelcase */
-  const headers = {
-    '#Code_commune_INSEE': 'codeInsee',
-    Nom_de_la_commune: 'nomCommune',
-    Code_postal: 'codePostal',
-    Libellé_d_acheminement: 'libelleAcheminement',
-    'Libell�_d_acheminement': 'libelleAcheminement', // Postal file url returns wrong header charset code (UTF-8 instead of ISO-8859-1)
-    Ligne_5: 'ligne5',
-  }
-  /* eslint-enable camelcase */
-
-  const dataRaw = await Papa.parse(postalFile, {
-    header: true,
-    transformHeader: name => headers[name] || name,
-    skipEmptyLines: true,
-  })
-
-  const districts = await getDistrictsFromCog(
-    dataRaw.data.map(({codeInsee}) => codeInsee)
-  )
-
-  const districtsByInseeCode = districts.reduce(
-    (acc, district) => ({
-      ...acc,
-      ...(!district?.meta || acc[district.meta?.insee?.cog] ? {} : {[district.meta.insee.cog]: district}),
-    }), {})
-
-  const banDistricts = Object.values(
-    (dataRaw?.data || []).map(({codeInsee, codePostal, libelleAcheminement}) => {
-      const {id} = districtsByInseeCode[codeInsee] || {}
-      return {id, codePostal: [codePostal], libelleAcheminement}
-    })
-      .reduce(
-        (acc, district) => {
-          if (district.id) {
-            if (acc[district.id]) {
-              acc[district.id].codePostal = [...acc[district.id].codePostal, ...district.codePostal]
-            } else {
-              acc[district.id] = district
-            }
-          }
-
-          return acc
-        }, {}
-      )
-  )
-
-  const patchBulkOperations = banDistricts.map(({id, codePostal, libelleAcheminement}) => ({
-    id,
-    meta: {
-      laPoste: {
-        codePostal,
-        libelleAcheminement,
-        source: 'La Poste - dataNOVA',
-      }
-    }
-  }))
-
-  patchDistricts(patchBulkOperations)
-
-  return banDistricts
-}
-
 app.route('/codePostal')
   .get(async (req, res) => {
     let response
@@ -289,8 +224,12 @@ app.route('/codePostal')
       // https://datanova.laposte.fr/data-fair/api/v1/datasets/laposte-hexasmal/raw
       const {url} = req.query
       const postalFile = await fetch(url)
+      const statusID = nanoid()
 
-      response = await updateDbFromDataNova(postalFile)
+      await apiQueue.add(
+        {dataType: 'district', jobType: 'updatePostalCode', data: postalFile, statusID},
+        {jobId: statusID, removeOnComplete: true}
+      )
     } catch (error) {
       const {message} = error
       response = {
@@ -307,8 +246,18 @@ app.route('/codePostal')
     let response
     try {
       const postalFile = req.body
+      const statusID = nanoid()
 
-      response = await updateDbFromDataNova(postalFile)
+      await apiQueue.add(
+        {dataType: 'district', jobType: 'updatePostalCode', data: postalFile, statusID},
+        {jobId: statusID, removeOnComplete: true}
+      )
+      response = {
+        date: new Date(),
+        status: 'success',
+        message: `Check the status of your request : ${BAN_API_URL}/job-status/${statusID}`,
+        response: {statusID},
+      }
     } catch (error) {
       const {message} = error
       response = {

--- a/lib/api/district/routes.js
+++ b/lib/api/district/routes.js
@@ -216,7 +216,7 @@ app.get('/cog/:cog', analyticsMiddleware, async (req, res) => {
   res.send(response)
 })
 
-app.route('/codePostal')
+app.route('/codePostal', auth)
   .get(async (req, res) => {
     let response
     try {

--- a/lib/api/district/routes.js
+++ b/lib/api/district/routes.js
@@ -1,10 +1,12 @@
 import 'dotenv/config.js' // eslint-disable-line import/no-unassigned-import
 import {customAlphabet} from 'nanoid'
 import express from 'express'
+import Papa from 'papaparse'
 import queue from '../../util/queue.cjs'
 import auth from '../../middleware/auth.js'
 import analyticsMiddleware from '../../middleware/analytics.js'
-import {getDistrict, getDistrictsFromCog, deleteDistrict} from './models.js'
+import fetch from '../../util/fetch.cjs'
+import {getDistrict, getDistrictFromCog, getDistrictsFromCog, deleteDistrict, patchDistricts} from './models.js'
 
 const apiQueue = queue('api')
 
@@ -189,7 +191,7 @@ app.get('/cog/:cog', analyticsMiddleware, async (req, res) => {
   let response
   try {
     const {cog} = req.params
-    const districts = await getDistrictsFromCog(cog)
+    const districts = await getDistrictFromCog(cog)
 
     if (!districts || districts.length === 0) {
       res.status(404).send('Request ID unknown')
@@ -214,5 +216,110 @@ app.get('/cog/:cog', analyticsMiddleware, async (req, res) => {
 
   res.send(response)
 })
+
+async function updateDbFromDataNova(postalFile) {
+  /* eslint-disable camelcase */
+  const headers = {
+    '#Code_commune_INSEE': 'codeInsee',
+    Nom_de_la_commune: 'nomCommune',
+    Code_postal: 'codePostal',
+    Libellé_d_acheminement: 'libelleAcheminement',
+    'Libell�_d_acheminement': 'libelleAcheminement', // Postal file url returns wrong header charset code (UTF-8 instead of ISO-8859-1)
+    Ligne_5: 'ligne5',
+  }
+  /* eslint-enable camelcase */
+
+  const dataRaw = await Papa.parse(postalFile, {
+    header: true,
+    transformHeader: name => headers[name] || name,
+    skipEmptyLines: true,
+  })
+
+  const districts = await getDistrictsFromCog(
+    dataRaw.data.map(({codeInsee}) => codeInsee)
+  )
+
+  const districtsByInseeCode = districts.reduce(
+    (acc, district) => ({
+      ...acc,
+      ...(!district?.meta || acc[district.meta?.insee?.cog] ? {} : {[district.meta.insee.cog]: district}),
+    }), {})
+
+  const banDistricts = Object.values(
+    (dataRaw?.data || []).map(({codeInsee, codePostal, libelleAcheminement}) => {
+      const {id} = districtsByInseeCode[codeInsee] || {}
+      return {id, codePostal: [codePostal], libelleAcheminement}
+    })
+      .reduce(
+        (acc, district) => {
+          if (district.id) {
+            if (acc[district.id]) {
+              acc[district.id].codePostal = [...acc[district.id].codePostal, ...district.codePostal]
+            } else {
+              acc[district.id] = district
+            }
+          }
+
+          return acc
+        }, {}
+      )
+  )
+
+  const patchBulkOperations = banDistricts.map(({id, codePostal, libelleAcheminement}) => ({
+    id,
+    meta: {
+      laPoste: {
+        codePostal,
+        libelleAcheminement,
+        source: 'La Poste - dataNOVA',
+      }
+    }
+  }))
+
+  patchDistricts(patchBulkOperations)
+
+  return banDistricts
+}
+
+app.route('/codePostal')
+  .get(async (req, res) => {
+    let response
+    try {
+      // On February 2024 the postal file url is :
+      // https://datanova.laposte.fr/data-fair/api/v1/datasets/laposte-hexasmal/raw
+      const {url} = req.query
+      const postalFile = await fetch(url)
+
+      response = await updateDbFromDataNova(postalFile)
+    } catch (error) {
+      const {message} = error
+      response = {
+        date: new Date(),
+        status: 'error',
+        message,
+        response: {},
+      }
+    }
+
+    res.send(response)
+  })
+  .post(express.text(), async (req, res) => {
+    let response
+    try {
+      const postalFile = req.body
+
+      response = await updateDbFromDataNova(postalFile)
+    } catch (error) {
+      const {message} = error
+      response = {
+        date: new Date(),
+        status: 'error',
+        message,
+        response: {},
+      }
+    }
+
+    res.send(response)
+  })
 
 export default app

--- a/lib/api/district/utils.js
+++ b/lib/api/district/utils.js
@@ -1,6 +1,7 @@
+import Papa from 'papaparse'
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema} from '../helper.js'
 import {banID} from '../schema.js'
-import {getDistricts} from './models.js'
+import {getDistricts, getDistrictsFromCog} from './models.js'
 import {banDistrictSchema} from './schema.js'
 
 const getExistingDistrictIDs = async districtIDs => {
@@ -65,4 +66,64 @@ export const checkDistrictsRequest = async (districts, actionType) => {
   }
 
   return report
+}
+
+export async function formatDataNova(postalFile) {
+  /* eslint-disable camelcase */
+  const headers = {
+    '#Code_commune_INSEE': 'codeInsee',
+    Nom_de_la_commune: 'nomCommune',
+    Code_postal: 'codePostal',
+    Libellé_d_acheminement: 'libelleAcheminement',
+    'Libell�_d_acheminement': 'libelleAcheminement', // Postal file url returns wrong header charset code (UTF-8 instead of ISO-8859-1)
+    Ligne_5: 'ligne5',
+  }
+  /* eslint-enable camelcase */
+
+  const dataRaw = await Papa.parse(postalFile, {
+    header: true,
+    transformHeader: name => headers[name] || name,
+    skipEmptyLines: true,
+  })
+
+  const districts = await getDistrictsFromCog(
+    dataRaw.data.map(({codeInsee}) => codeInsee)
+  )
+
+  const districtsByInseeCode = districts.reduce(
+    (acc, district) => ({
+      ...acc,
+      ...(!district?.meta || acc[district.meta?.insee?.cog] ? {} : {[district.meta.insee.cog]: district}),
+    }), {})
+
+  const banDistricts = Object.values(
+    (dataRaw?.data || []).map(({codeInsee, codePostal, libelleAcheminement}) => {
+      const {id} = districtsByInseeCode[codeInsee] || {}
+      return {id, codePostal: [codePostal], libelleAcheminement}
+    })
+      .reduce(
+        (acc, district) => {
+          if (district.id) {
+            if (acc[district.id]) {
+              acc[district.id].codePostal = [...acc[district.id].codePostal, ...district.codePostal]
+            } else {
+              acc[district.id] = district
+            }
+          }
+
+          return acc
+        }, {}
+      )
+  )
+
+  return banDistricts.map(({id, codePostal, libelleAcheminement}) => ({
+    id,
+    meta: {
+      laPoste: {
+        codePostal,
+        libelleAcheminement,
+        source: 'La Poste - dataNOVA',
+      }
+    }
+  }))
 }


### PR DESCRIPTION
Cette PR vise à améliorer le calcul des codes postaux dans la base postgres à l'aide de données fournies par La Poste :
- Utilisation des données de la base officielle des codes postaux pour les communes mono-distribuées
- Utilisation de contours postaux fournis par La Poste pour les communes pluri-distribuées
- Dans le cas où aucun code postal n'est trouvé, on utilise l'ancienne méthode de calcul (fichier FIMOCT de la DGFIP)

Pour cela, cette PR ajoute :
- La création de deux vues pour le calcul des meta (dont les codes postaux) dans postgres
- L'utilisation de ces vues lors des exports de postgres vers mongo
- Une nouvelle route d'API pour mettre à jour les codes postaux des districts à l'aide de la base officielle des codes postaux
fix #363 