### PR TITLE
Fix export only active items from main to exploitation db

### DIFF
--- a/lib/api/consumers/export-to-exploitation-db-consumer.js
+++ b/lib/api/consumers/export-to-exploitation-db-consumer.js
@@ -69,7 +69,7 @@ const commonToponymPageQuery = `
   ON
     CT.id = A."mainCommonToponymID"
     OR CT.id = ANY(A."secondaryCommonToponymIDs")
-  WHERE CT."districtID" = :districtID
+  WHERE CT."districtID" = :districtID AND upper(CT.range_validity) IS NULL
   GROUP BY CT.id
   ORDER BY CT.id ASC
   OFFSET :offset
@@ -86,7 +86,7 @@ const addressPageQuery = `
     ST_Transform(ST_Buffer(ST_Transform(ST_Envelope(ST_SetSRID(ST_GeomFromGeoJSON((A.positions[1])->'geometry'), 4326)), 2154), :bboxBuffer, 'join=mitre endcap=square'), 4326) AS bbox
   FROM
     ban.address AS A
-  WHERE A."districtID" = :districtID
+  WHERE A."districtID" = :districtID AND upper(A.range_validity) IS NULL
   ORDER BY A.id ASC
   OFFSET :offset
   LIMIT :limit


### PR DESCRIPTION
Fix : when exporting from main db (postgres) to exploitation db (mongo), we export, for one district, all items from db tables (address, common_toponym and district). As now we can have non-active items in dbs, we need to export only active items.

This fix adds a condition `upper(table.range_validity) IS NULL` in the sql queries (where table can be address and common_toponym)