### PR TITLE
[Init DB with data] - Add seed mechanism

### DIFF
--- a/db-migrations/seeders/20240417084446-init-districts.cjs
+++ b/db-migrations/seeders/20240417084446-init-districts.cjs
@@ -1,0 +1,31 @@
+'use strict'
+
+const districts = [
+  {
+    id: '55c7f562-4f6b-4dac-a685-19efd9afe42c',
+    labels: [{isoCode: 'fra', value: 'Thourotte'}],
+    updateDate: '2023-01-01',
+    meta: {insee: {cog: '60636'}}
+  },
+]
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      INSERT INTO ban.district (id, labels, "updateDate", meta) 
+      VALUES 
+        ${districts.map(({id, labels, updateDate, meta}) => (`
+          (
+            '${id}', 
+            (ARRAY['${labels.map(label => JSON.stringify(label)).join(',')}'])::jsonb[],
+            '${updateDate}',
+            '${JSON.stringify(meta)}'::jsonb
+          )`)).join(',')}
+      ;`)
+  },
+
+  async down(queryInterface) {
+    return queryInterface.bulkDelete({tableName: 'district', schema: 'ban'}, null, {})
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "toolbox:snapshot": "node toolbox.dev/scripts/db-snapshot.js",
     "toolbox:compare": "node toolbox.dev/scripts/compare-data-from-db-snapshot-and-current-db",
     "migrate:up": "npx sequelize-cli db:migrate",
-    "migrate:undo": "npx sequelize-cli db:migrate:undo"
+    "migrate:undo": "npx sequelize-cli db:migrate:undo",
+    "seed:up": "npx sequelize-cli db:seed:all",
+    "seed:undo": "npx sequelize-cli db:seed:undo"
   },
   "dependencies": {
     "@ban-team/fantoir": "^0.15.0",

--- a/toolbox.dev/scripts/compare-data-from-db-snapshot-and-current-db.js
+++ b/toolbox.dev/scripts/compare-data-from-db-snapshot-and-current-db.js
@@ -28,7 +28,7 @@ const main = async () => {
     const filePath = path.join(snapshotFolder, file)
     const fileData = JSON.parse(await fs.readFile(filePath))
 
-    const dbData = DISTRICT_TO_SNAPSHOT
+    const dbData = DISTRICT_TO_SNAPSHOT.length > 0
       ? await collection.find({codeCommune: {$in: DISTRICT_TO_SNAPSHOT}}).toArray()
       : await collection.find().toArray()
 

--- a/toolbox.dev/scripts/db-snapshot.js
+++ b/toolbox.dev/scripts/db-snapshot.js
@@ -12,7 +12,7 @@ const __dirname = dirname(__filename)
 const SNAPSHOT_FOLDER_NAME = 'ban-db-snapshot'
 
 const collectionNotToSnapshot = new Set(
-  ['metrics', 'sources_adresses', 'sources_voies', 'sources_communes', 'sources_parts', 'address_test', 'commonToponym_test', 'district_test', 'job_status']
+  ['metrics', 'sources_adresses', 'sources_voies', 'sources_communes', 'sources_parts', 'address_test', 'commonToponym_test', 'district_test', 'job_status', 'pseudo_codes_voies']
 )
 
 const main = async () => {
@@ -36,7 +36,7 @@ const main = async () => {
     }
 
     const collection = mongo.db.collection(collectionName)
-    const data = DISTRICT_TO_SNAPSHOT
+    const data = DISTRICT_TO_SNAPSHOT.length > 0
       ? await collection.find({codeCommune: {$in: DISTRICT_TO_SNAPSHOT}}).toArray()
       : await collection.find().toArray()
     const filePath = path.join(initDir, `${collectionName}.json`)


### PR DESCRIPTION
# Context 

When working locally, we need to have data into the db to develop, to test, ... etc

# Enhancement

This PRs aims to add a "seed" mechanism to be able to insert/modify/delete data into the DB easily thanks to sequelize-cli.

# How to test 

1- Run the command : 
`npm run seed:up`

2- Check you local db : the data from the file `db-migrations/seeders/20240417084446-init-districts.cjs` must have been inserted into your local db.