### PR TITLE
Add with ban id stats

### DIFF
--- a/lib/models/ban.cjs
+++ b/lib/models/ban.cjs
@@ -17,7 +17,8 @@ async function computeStats() {
     nbAdresses: sumBy(banCommunesRecords, 'nbNumeros'),
     nbAdressesCertifiees: sumBy(banCommunesRecords, 'nbNumerosCertifies'),
     nbCommunesCouvertes: banCommunesRecords.length,
-    populationCouverte: sumBy(banCommunesRecords, 'population')
+    populationCouverte: sumBy(banCommunesRecords, 'population'),
+    nbCommunesAvecBanId: sumBy(banCommunesRecords, 'useBanId')
   }
 
   const balCommunesRecords = communesRecords.filter(c => c.typeComposition === 'bal')
@@ -26,7 +27,8 @@ async function computeStats() {
     nbAdresses: sumBy(balCommunesRecords, 'nbNumeros'),
     nbAdressesCertifiees: sumBy(balCommunesRecords, 'nbNumerosCertifies'),
     nbCommunesCouvertes: balCommunesRecords.length,
-    populationCouverte: sumBy(balCommunesRecords, 'population')
+    populationCouverte: sumBy(balCommunesRecords, 'population'),
+    nbCommunesAvecBanId: sumBy(balCommunesRecords, 'useBanId')
   }
 
   return {france, ban, bal}
@@ -49,7 +51,8 @@ async function computeFilteredStats(codesCommune) {
     nbAdresses: sumBy(banCommunesRecords, 'nbNumeros'),
     nbAdressesCertifiees: sumBy(banCommunesRecords, 'nbNumerosCertifies'),
     nbCommunesCouvertes: banCommunesRecords.length,
-    populationCouverte: sumBy(banCommunesRecords, 'population')
+    populationCouverte: sumBy(banCommunesRecords, 'population'),
+    nbCommunesAvecBanId: sumBy(banCommunesRecords, 'useBanId')
   }
 
   const balCommunesRecords = communesRecords.filter(c => c.typeComposition === 'bal')
@@ -58,7 +61,8 @@ async function computeFilteredStats(codesCommune) {
     nbAdresses: sumBy(balCommunesRecords, 'nbNumeros'),
     nbAdressesCertifiees: sumBy(balCommunesRecords, 'nbNumerosCertifies'),
     nbCommunesCouvertes: balCommunesRecords.length,
-    populationCouverte: sumBy(balCommunesRecords, 'population')
+    populationCouverte: sumBy(balCommunesRecords, 'population'),
+    nbCommunesAvecBanId: sumBy(balCommunesRecords, 'useBanId')
   }
 
   return {total, ban, bal}


### PR DESCRIPTION
# Context

With the deployment of the new technical platform, we need to have data on the number o district that uses banIDs

# Enhancement

This PR : 
- adds a "nbCommunesAvecBanId" calcul is the stat compute