### PR TITLE
Fixed nbCommunesAvecBanId stats

### DIFF
--- a/lib/models/ban.cjs
+++ b/lib/models/ban.cjs
@@ -52,7 +52,7 @@ async function computeFilteredStats(codesCommune) {
     nbAdressesCertifiees: sumBy(banCommunesRecords, 'nbNumerosCertifies'),
     nbCommunesCouvertes: banCommunesRecords.length,
     populationCouverte: sumBy(banCommunesRecords, 'population'),
-    nbCommunesAvecBanId: sumBy(banCommunesRecords, 'useBanId')
+    nbCommunesAvecBanId: sumBy(banCommunesRecords, 'withBanId')
   }
 
   const balCommunesRecords = communesRecords.filter(c => c.typeComposition === 'bal')
@@ -62,7 +62,7 @@ async function computeFilteredStats(codesCommune) {
     nbAdressesCertifiees: sumBy(balCommunesRecords, 'nbNumerosCertifies'),
     nbCommunesCouvertes: balCommunesRecords.length,
     populationCouverte: sumBy(balCommunesRecords, 'population'),
-    nbCommunesAvecBanId: sumBy(balCommunesRecords, 'useBanId')
+    nbCommunesAvecBanId: sumBy(balCommunesRecords, 'withBanId')
   }
 
   return {total, ban, bal}


### PR DESCRIPTION
Fix : the "key" to use for the "nbCommunesAvecBanId" is `withBanId` and not `useBanId`