### PR TITLE
Modified delta report to update items outside district

### DIFF
--- a/lib/api/address/__mocks__/address-models.js
+++ b/lib/api/address/__mocks__/address-models.js
@@ -1,13 +1,19 @@
 import {bddAddressMock} from './address-data-mock.js'
 
-export async function getAddresses(addressIDs) {
-  return bddAddressMock.filter(({id}) => addressIDs.includes(id))
-}
+export async function getAddressesByFilters(filters, attributes) {
+  return bddAddressMock.filter(address => {
+    for (const [key, value] of Object.entries(filters)) {
+      if (Array.isArray(value)) {
+        if (!value.includes(address[key])) {
+          return false
+        }
+      } else if (address[key] !== value) {
+        return false
+      }
+    }
 
-export async function getAllAddressIDsWithHashFromDistrict(districtID) {
-  return bddAddressMock.filter(({districtID: districtIDAddress}) => districtIDAddress === districtID).map(({id, meta, isActive}) => ({id, hash: meta?.idfix?.hash, isActive}))
-}
-
-export async function getAllAddressIDsOutsideDistrict(addressIDs, districtID) {
-  return bddAddressMock.filter(({id, districtID: districtIDAddress}) => addressIDs.includes(id) && districtIDAddress !== districtID).map(({id}) => id)
+    return true
+  }).map(address => (
+    attributes ? Object.fromEntries(attributes.map(attribute => [attribute, address[attribute]])) : address
+  ))
 }

--- a/lib/api/address/models.js
+++ b/lib/api/address/models.js
@@ -1,19 +1,10 @@
-import {Op} from 'sequelize'
 import {Address} from '../../util/sequelize.js'
 
 export const getAddress = addressID => Address.findByPk(addressID, {raw: true})
 
 export const getAddresses = addressIDs => Address.findAll({where: {id: addressIDs}, raw: true})
 
-export const getAllAddressIDsWithHashFromDistrict = async districtID => {
-  const addresses = await Address.findAll({where: {districtID}, attributes: ['id', 'meta', 'isActive'], raw: true})
-  return addresses.map(address => ({id: address.id, hash: address.meta?.idfix?.hash, isActive: address.isActive}))
-}
-
-export const getAllAddressIDsOutsideDistrict = async (addressIDs, districtID) => {
-  const addresses = await Address.findAll({where: {id: addressIDs, districtID: {[Op.ne]: districtID}}, attributes: ['id'], raw: true})
-  return addresses.map(address => address.id)
-}
+export const getAddressesByFilters = (filters, attributes) => Address.findAll({where: filters, attributes, raw: true})
 
 export const setAddresses = addresses => Address.bulkCreate(addresses)
 

--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -1,11 +1,11 @@
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfCommonToponymsExist, checkIfDistrictsExist} from '../helper.js'
 import {banID} from '../schema.js'
-import {getAddresses, getAllAddressIDsWithHashFromDistrict, getAllAddressIDsOutsideDistrict} from './models.js'
+import {getAddressesByFilters} from './models.js'
 import {banAddressSchema} from './schema.js'
 
 const getExistingAddressIDs = async addressIDs => {
-  const existingAddresses = await getAddresses(addressIDs)
-  return existingAddresses.map(addresses => addresses.id)
+  const existingAddresses = await getAddressesByFilters({id: addressIDs}, ['id'])
+  return existingAddresses.map(address => address.id)
 }
 
 export const checkAddressesIDsRequest = async (addressIDs, actionType, defaultReturn = true) => {
@@ -83,37 +83,44 @@ export const checkAddressesRequest = async (addresses, actionType) => {
 }
 
 export const getDeltaReport = async (addressIDsWithHash, districtID) => {
-  const addressIDsWithHashMap = new Map(addressIDsWithHash.map(({id, hash}) => [id, hash]))
-  const allAddressIDsWithHashFromDistrict = await getAllAddressIDsWithHashFromDistrict(districtID)
-  const allAddressIDsWithHashFromDistrictMap = new Map(allAddressIDsWithHashFromDistrict.map(({id, hash, isActive}) => [id, {hash, isActive}]))
-
-  let idsToCreate = []
+  const idsToCreate = []
   const idsToUpdate = []
   const idsToDelete = []
 
-  for (const [id, hash] of addressIDsWithHashMap) {
-    if (allAddressIDsWithHashFromDistrictMap.has(id)) {
-      if (allAddressIDsWithHashFromDistrictMap.get(id).hash !== hash || !allAddressIDsWithHashFromDistrictMap.get(id).isActive) {
+  // Get all existing addresses inside and outside the district from db
+  const addressIDs = addressIDsWithHash.map(({id}) => id)
+  const existingAddresses = await getAddressesByFilters({id: addressIDs}, ['id', 'meta', 'isActive'])
+  const existingAddressesMap = new Map(existingAddresses.map(({id, meta, isActive}) => [id, {hash: meta?.idfix?.hash, isActive}]))
+
+  for (const {id, hash} of addressIDsWithHash) {
+    if (existingAddressesMap.has(id)) {
+      // The address is already existing in the db
+      const existingAddressIsActive = existingAddressesMap.get(id).isActive
+      const existingAddressHash = existingAddressesMap.get(id).hash
+      // If the address has a different hash we need to update it
+      // If the address is not active, it means that we need to reactivate it (even if the hash is the same)
+      if (existingAddressHash !== hash || !existingAddressIsActive) {
         idsToUpdate.push(id)
       }
     } else {
+      // The address is not existing in the db
       idsToCreate.push(id)
     }
   }
 
-  for (const id of allAddressIDsWithHashFromDistrictMap.keys()) {
-    if (!addressIDsWithHashMap.has(id) && allAddressIDsWithHashFromDistrictMap.get(id).isActive) {
+  // Get all addresses that are part of the district from the db
+  const allAddressesFromDistrict = await getAddressesByFilters({districtID}, ['id', 'meta', 'isActive'])
+  const allAddressesFromDistrictMap = new Map(allAddressesFromDistrict.map(({id, meta, isActive}) => [id, {hash: meta?.idfix?.hash, isActive}]))
+  const addressIDsWithHashMap = new Map(addressIDsWithHash.map(({id, hash}) => [id, hash]))
+  for (const id of allAddressesFromDistrictMap.keys()) {
+    // If a address is in the district but not in the request, we need to delete it (only if not active)
+    const addressFromDistrictIsActive = allAddressesFromDistrictMap.get(id).isActive
+    if (!addressIDsWithHashMap.has(id) && addressFromDistrictIsActive) {
       idsToDelete.push(id)
     }
   }
 
-  const idsUnauthorized = await getAllAddressIDsOutsideDistrict(idsToCreate, districtID)
-  const idsUnauthorizedSet = new Set(idsUnauthorized)
-  if (idsUnauthorized.length > 0) {
-    idsToCreate = idsToCreate.filter(id => !idsUnauthorizedSet.has(id))
-  }
-
-  return {idsToCreate, idsToUpdate, idsToDelete, idsUnauthorized}
+  return {idsToCreate, idsToUpdate, idsToDelete}
 }
 
 export const formatAddress = address => {

--- a/lib/api/address/utils.spec.js
+++ b/lib/api/address/utils.spec.js
@@ -175,7 +175,6 @@ describe('getDeltaReport', () => {
       idsToCreate: addressMock.map(({id}) => id),
       idsToUpdate: [],
       idsToDelete: bddAddressMock.map(({id}) => id),
-      idsUnauthorized: []
     })
   })
   it('Should not return anything to update as hashes are equals', async () => {
@@ -186,7 +185,6 @@ describe('getDeltaReport', () => {
       idsToCreate: [],
       idsToUpdate: [],
       idsToDelete: [],
-      idsUnauthorized: []
     })
   })
   it('Should return only one id to update as hashes are different', async () => {
@@ -198,7 +196,6 @@ describe('getDeltaReport', () => {
       idsToCreate: [],
       idsToUpdate: [bddAddressMock[0].id],
       idsToDelete: [],
-      idsUnauthorized: []
     })
   })
 })

--- a/lib/api/common-toponym/__mocks__/common-toponym-models.js
+++ b/lib/api/common-toponym/__mocks__/common-toponym-models.js
@@ -1,13 +1,23 @@
 import {bddCommonToponymMock} from './common-toponym-data-mock.js'
 
 export async function getCommonToponyms(commonToponymIDs) {
-  return bddCommonToponymMock.filter(({id}) => commonToponymIDs.includes(id))
+  return bddCommonToponymMock.filter(commonToponym => commonToponymIDs.includes(commonToponym.id))
 }
 
-export async function getAllCommonToponymIDsWithHashFromDistrict(districtID) {
-  return bddCommonToponymMock.filter(({districtID: districtIDCommonToponym}) => districtIDCommonToponym === districtID).map(({id, meta, isActive}) => ({id, hash: meta?.idfix?.hash, isActive}))
-}
+export async function getCommonToponymsByFilters(filters, attributes) {
+  return bddCommonToponymMock.filter(commonToponym => {
+    for (const [key, value] of Object.entries(filters)) {
+      if (Array.isArray(value)) {
+        if (!value.includes(commonToponym[key])) {
+          return false
+        }
+      } else if (commonToponym[key] !== value) {
+        return false
+      }
+    }
 
-export async function getAllCommonToponymIDsOutsideDistrict(commonToponymIDs, districtID) {
-  return bddCommonToponymMock.filter(({id, districtID: districtIDCommonToponym}) => commonToponymIDs.includes(id) && districtIDCommonToponym !== districtID).map(({id}) => id)
+    return true
+  }).map(commonToponym => (
+    attributes ? Object.fromEntries(attributes.map(attribute => [attribute, commonToponym[attribute]])) : commonToponym
+  ))
 }

--- a/lib/api/common-toponym/models.js
+++ b/lib/api/common-toponym/models.js
@@ -1,23 +1,10 @@
-import {Op} from 'sequelize'
 import {CommonToponym} from '../../util/sequelize.js'
 
 export const getCommonToponym = commonToponymID => CommonToponym.findByPk(commonToponymID, {raw: true})
 
 export const getCommonToponyms = commonToponymIDs => CommonToponym.findAll({where: {id: commonToponymIDs}, raw: true})
 
-export const getAllCommonToponymIDsWithHashFromDistrict = async districtID => {
-  const commonToponyms = await CommonToponym.findAll(
-    {where: {districtID}, attributes: ['id', 'meta', 'isActive'], raw: true}
-  )
-  return commonToponyms.map(commonToponym => ({id: commonToponym.id, hash: commonToponym.meta?.idfix?.hash, isActive: commonToponym.isActive}))
-}
-
-export const getAllCommonToponymIDsOutsideDistrict = async (commonToponymIDs, districtID) => {
-  const commonToponyms = await CommonToponym.findAll(
-    {where: {id: commonToponymIDs, districtID: {[Op.ne]: districtID}}, attributes: ['id'], raw: true}
-  )
-  return commonToponyms.map(commonToponym => commonToponym.id)
-}
+export const getCommonToponymsByFilters = (filters, attributes) => CommonToponym.findAll({where: filters, attributes, raw: true})
 
 export const setCommonToponyms = commonToponyms => CommonToponym.bulkCreate(commonToponyms)
 

--- a/lib/api/common-toponym/utils.js
+++ b/lib/api/common-toponym/utils.js
@@ -1,10 +1,10 @@
 import {checkDataFormat, dataValidationReportFrom, checkIdsIsUniq, checkIdsIsVacant, checkIdsIsAvailable, checkDataShema, checkIdsShema, checkIfDistrictsExist} from '../helper.js'
 import {banID} from '../schema.js'
-import {getCommonToponyms, getAllCommonToponymIDsWithHashFromDistrict, getAllCommonToponymIDsOutsideDistrict} from './models.js'
+import {getCommonToponymsByFilters} from './models.js'
 import {banCommonToponymSchema} from './schema.js'
 
 const getExistingCommonToponymIDs = async commonToponymIDs => {
-  const existingCommonToponyms = await getCommonToponyms(commonToponymIDs)
+  const existingCommonToponyms = await getCommonToponymsByFilters({id: commonToponymIDs}, ['id'])
   return existingCommonToponyms.map(commonToponym => commonToponym.id)
 }
 
@@ -75,37 +75,44 @@ export const checkCommonToponymsRequest = async (commonToponyms, actionType) => 
 }
 
 export const getDeltaReport = async (commonToponymIDsWithHash, districtID) => {
-  const commonToponymIDsWithHashMap = new Map(commonToponymIDsWithHash.map(({id, hash}) => [id, hash]))
-  const allCommonToponymIDsWithHashFromDistrict = await getAllCommonToponymIDsWithHashFromDistrict(districtID)
-  const allCommonToponymIDsWithHashFromDistrictMap = new Map(allCommonToponymIDsWithHashFromDistrict.map(({id, hash, isActive}) => [id, {hash, isActive}]))
-
-  let idsToCreate = []
+  const idsToCreate = []
   const idsToUpdate = []
   const idsToDelete = []
 
-  for (const [id, hash] of commonToponymIDsWithHashMap) {
-    if (allCommonToponymIDsWithHashFromDistrictMap.has(id)) {
-      if (allCommonToponymIDsWithHashFromDistrictMap.get(id).hash !== hash || !allCommonToponymIDsWithHashFromDistrictMap.get(id).isActive) {
+  // Get all existing common toponyms inside and outside the district from db
+  const commonToponymIDs = commonToponymIDsWithHash.map(({id}) => id)
+  const existingCommonToponyms = await getCommonToponymsByFilters({id: commonToponymIDs}, ['id', 'meta', 'isActive'])
+  const existingCommonToponymsMap = new Map(existingCommonToponyms.map(({id, meta, isActive}) => [id, {hash: meta?.idfix?.hash, isActive}]))
+
+  for (const {id, hash} of commonToponymIDsWithHash) {
+    if (existingCommonToponymsMap.has(id)) {
+      // The common toponym is already existing in the db
+      const existingCommonToponymIsActive = existingCommonToponymsMap.get(id).isActive
+      const existingCommonToponymHash = existingCommonToponymsMap.get(id).hash
+      // If the common toponym has a different hash we need to update it
+      // If the common toponym is not active, it means that we need to reactivate it (even if the hash is the same)
+      if (existingCommonToponymHash !== hash || !existingCommonToponymIsActive) {
         idsToUpdate.push(id)
       }
     } else {
+      // The common toponym is not existing in the db
       idsToCreate.push(id)
     }
   }
 
-  for (const id of allCommonToponymIDsWithHashFromDistrictMap.keys()) {
-    if (!commonToponymIDsWithHashMap.has(id) && allCommonToponymIDsWithHashFromDistrictMap.get(id).isActive) {
+  // Get all common toponyms that are part of the district from the db
+  const allCommonToponymsFromDistrict = await getCommonToponymsByFilters({districtID}, ['id', 'meta', 'isActive'])
+  const allCommonToponymsFromDistrictMap = new Map(allCommonToponymsFromDistrict.map(({id, meta, isActive}) => [id, {hash: meta?.idfix?.hash, isActive}]))
+  const commonToponymIDsWithHashMap = new Map(commonToponymIDsWithHash.map(({id, hash}) => [id, hash]))
+  for (const id of allCommonToponymsFromDistrictMap.keys()) {
+    // If a common toponym is in the district but not in the request, we need to delete it (only if not active)
+    const commonToponymFromDistrictIsActive = allCommonToponymsFromDistrictMap.get(id).isActive
+    if (!commonToponymIDsWithHashMap.has(id) && commonToponymFromDistrictIsActive) {
       idsToDelete.push(id)
     }
   }
 
-  const idsUnauthorized = await getAllCommonToponymIDsOutsideDistrict(idsToCreate, districtID)
-  const idsUnauthorizedSet = new Set(idsUnauthorized)
-  if (idsUnauthorized.length > 0) {
-    idsToCreate = idsToCreate.filter(id => !idsUnauthorizedSet.has(id))
-  }
-
-  return {idsToCreate, idsToUpdate, idsToDelete, idsUnauthorized}
+  return {idsToCreate, idsToUpdate, idsToDelete}
 }
 
 export const formatCommonToponym = commonToponym => {

--- a/lib/api/common-toponym/utils.spec.js
+++ b/lib/api/common-toponym/utils.spec.js
@@ -150,7 +150,6 @@ describe('getDeltaReport', () => {
       idsToCreate: commonToponymMock.map(({id}) => id),
       idsToUpdate: [],
       idsToDelete: bddCommonToponymMock.map(({id}) => id),
-      idsUnauthorized: []
     })
   })
   it('Should not return anything to update as hashes are equals', async () => {
@@ -161,7 +160,6 @@ describe('getDeltaReport', () => {
       idsToCreate: [],
       idsToUpdate: [],
       idsToDelete: [],
-      idsUnauthorized: []
     })
   })
   it('Should return only one id to update as hashes are different', async () => {
@@ -173,7 +171,6 @@ describe('getDeltaReport', () => {
       idsToCreate: [],
       idsToUpdate: [bddCommonToponymMock[0].id],
       idsToDelete: [],
-      idsUnauthorized: []
     })
   })
 })


### PR DESCRIPTION
# Context 

When creating the delta report to inform id-fix what to create/update/delete, we were only considering the context of a district for "updates"

# Enhancement

This PR modified the delta-report behavior so that :
- If an address or a common toponym is outside the district, it is now considered in the "update" array (instead of the "unauthorized" array).