### PR TITLE
New api route to force export from postgres to mongo

### DIFF
--- a/lib/api/address/routes.js
+++ b/lib/api/address/routes.js
@@ -34,10 +34,11 @@ app.route('/')
         response: {statusID},
       }
     } catch (error) {
+      const {message} = error
       response = {
         date: new Date(),
         status: 'error',
-        message: error,
+        message,
         response: {},
       }
     }
@@ -61,10 +62,11 @@ app.route('/')
         response: {statusID},
       }
     } catch (error) {
+      const {message} = error
       response = {
         date: new Date(),
         status: 'error',
-        message: error,
+        message,
         response: {},
       }
     }
@@ -88,10 +90,11 @@ app.route('/')
         response: {statusID},
       }
     } catch (error) {
+      const {message} = error
       response = {
         date: new Date(),
         status: 'error',
-        message: error,
+        message,
         response: {},
       }
     }
@@ -177,10 +180,11 @@ app.post('/delete', auth, analyticsMiddleware, async (req, res) => {
       response: {statusID},
     }
   } catch (error) {
+    const {message} = error
     response = {
       date: new Date(),
       status: 'error',
-      message: error,
+      message,
       response: {},
     }
   }
@@ -205,10 +209,11 @@ app.post('/delta-report', auth, analyticsMiddleware, async (req, res) => {
       response: deltaReport,
     }
   } catch (error) {
+    const {message} = error
     response = {
       date: new Date(),
       status: 'error',
-      message: error,
+      message,
       response: {},
     }
   }

--- a/lib/api/common-toponym/routes.js
+++ b/lib/api/common-toponym/routes.js
@@ -34,10 +34,11 @@ app.route('/')
         response: {statusID},
       }
     } catch (error) {
+      const {message} = error
       response = {
         date: new Date(),
         status: 'error',
-        message: error,
+        message,
         response: {},
       }
     }
@@ -61,10 +62,11 @@ app.route('/')
         response: {statusID},
       }
     } catch (error) {
+      const {message} = error
       response = {
         date: new Date(),
         status: 'error',
-        message: error,
+        message,
         response: {},
       }
     }
@@ -88,10 +90,11 @@ app.route('/')
         response: {statusID},
       }
     } catch (error) {
+      const {message} = error
       response = {
         date: new Date(),
         status: 'error',
-        message: error,
+        message,
         response: {},
       }
     }
@@ -177,10 +180,11 @@ app.post('/delete', auth, analyticsMiddleware, async (req, res) => {
       response: {statusID},
     }
   } catch (error) {
+    const {message} = error
     response = {
       date: new Date(),
       status: 'error',
-      message: error,
+      message,
       response: {},
     }
   }
@@ -205,10 +209,11 @@ app.post('/delta-report', auth, analyticsMiddleware, async (req, res) => {
       response: deltaReport,
     }
   } catch (error) {
+    const {message} = error
     response = {
       date: new Date(),
       status: 'error',
-      message: error,
+      message,
       response: {},
     }
   }

--- a/lib/api/district/routes.js
+++ b/lib/api/district/routes.js
@@ -34,10 +34,11 @@ app.route('/')
         response: {statusID},
       }
     } catch (error) {
+      const {message} = error
       response = {
         date: new Date(),
         status: 'error',
-        message: error,
+        message,
         response: {},
       }
     }
@@ -61,10 +62,11 @@ app.route('/')
         response: {statusID},
       }
     } catch (error) {
+      const {message} = error
       response = {
         date: new Date(),
         status: 'error',
-        message: error,
+        message,
         response: {},
       }
     }
@@ -88,10 +90,11 @@ app.route('/')
         response: {statusID},
       }
     } catch (error) {
+      const {message} = error
       response = {
         date: new Date(),
         status: 'error',
-        message: error,
+        message,
         response: {},
       }
     }
@@ -177,10 +180,11 @@ app.post('/delete', auth, analyticsMiddleware, async (req, res) => {
       response: {statusID},
     }
   } catch (error) {
+    const {message} = error
     response = {
       date: new Date(),
       status: 'error',
-      message: error,
+      message,
       response: {},
     }
   }

--- a/lib/api/export-to-exploitation-db/routes.js
+++ b/lib/api/export-to-exploitation-db/routes.js
@@ -1,0 +1,47 @@
+import 'dotenv/config.js' // eslint-disable-line import/no-unassigned-import
+import express from 'express'
+import queue from '../../util/queue.cjs'
+import auth from '../../middleware/auth.js'
+import {getDistricts} from '../district/models.js'
+
+const exportToExploitationDBQueue = queue('export-to-exploitation-db')
+
+const app = new express.Router()
+
+app.route('/districts')
+  .post(auth, async (req, res) => {
+    let response
+    try {
+      const {districtIDs} = req.body
+
+      if (!districtIDs || districtIDs.length === 0) {
+        res.status(400).send('districtIDs should not be empty')
+      }
+
+      const districts = await getDistricts(districtIDs)
+      if (districts.length !== districtIDs.length) {
+        res.status(404).send('Some districts not found')
+      }
+
+      await Promise.all(districtIDs.map(async districtID => exportToExploitationDBQueue.add({districtID}, {removeOnComplete: true, removeOnFail: true})))
+
+      response = {
+        date: new Date(),
+        status: 'success',
+        response: {},
+      }
+    } catch (error) {
+      const {message} = error
+      response = {
+        date: new Date(),
+        status: 'error',
+        message,
+        response: {},
+      }
+    }
+
+    res.send(response)
+  })
+
+export default app
+

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -7,6 +7,7 @@ import districtRoutes from './district/routes.js'
 import statusRoutes from './job-status/routes.js'
 import banIdRoutes from './ban-id/routes.js'
 import certificatRoutes from './certificate/routes.js'
+import exportToExploitationDBRoutes from './export-to-exploitation-db/routes.js'
 
 const app = new express.Router()
 
@@ -16,5 +17,6 @@ app.use('/district', districtRoutes)
 app.use('/job-status', statusRoutes)
 app.use('/ban-id', banIdRoutes)
 app.use('/certificate', certificatRoutes)
+app.use('/export-to-exploitation-db', exportToExploitationDBRoutes)
 
 export default app


### PR DESCRIPTION
# Context 

In order to force an update from postgres to mongo, we need a new API route

# Enhancement

This PR adds a new route : 
- POST `export-to-exploitation-db/districts` that takes a body with the list of district IDs in an array : `{districtIDs:["","",...]}`. This route adds a job in the "export-to-exploitation-db" queue for each district ID requested.