### PR TITLE
Fixed hash generation for common toponym id legacy

### DIFF
--- a/lib/api/consumers/format-to-legacy-helpers.js
+++ b/lib/api/consumers/format-to-legacy-helpers.js
@@ -113,7 +113,7 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
     legacyCommonToponymId = `${cog}_${pseudoCodeVoieGenerator.getCode(legacyLabelValue, codeAncienneCommune)}`.toLowerCase()
     // If the pseudo code is already used, we generate a new one with a hash from the common toponym id
     if (commonToponymLegacyIDSet.has(legacyCommonToponymId)) {
-      legacyCommonToponymId = `${cog}_${createHmac('sha256').update(id).digest('hex').slice(0, 5)}`
+      legacyCommonToponymId = `${cog}_${createHmac('sha256', 'ban').update(id).digest('hex').slice(0, 5)}`
     }
   }
 


### PR DESCRIPTION
# Context

When exporting data from postgresql (main database) to mongodb (exploitation database), we generate legacy ids for common toponym. In the case we cannot find a fantoir code or if the fantoir code is already used on another common toponym, we generate a pseudo code. If the pseudo code is also already used, we generate a hash base on the ban id.

# Enhancement 

This PR fix : 
- the generation of the hash that uses the `createHmac` method (from `node:crypto`) by adding a mandatory 'secret'.