### PR TITLE
Fixed legacy compose cli to get only string args

### DIFF
--- a/lib/compose/cli.cjs
+++ b/lib/compose/cli.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 require('dotenv').config()
-const argv = require('minimist')(process.argv.slice(2))
+const argv = require('minimist')(process.argv.slice(2), {string: '_'})
 const mongo = require('../util/mongo.cjs')
 const {getAskedComposition} = require('../models/commune.cjs')
 const {runInParallel} = require('../util/parallel.cjs')


### PR DESCRIPTION
# Context 

To compose a district manually, ban-plateforme has a "compose" command that can get a insee code or a list of insee codes as arguments. The issue is that when passing a code insee that has a '0' at the beginning, the `minimist` lib converts it to number. Example : `yarn compose 08053` => the code insee is converted to `8053` by the lib

# Enhancement

This PR adds an option to the 'minimist' lib to only get string arguments.

From `minimist` documentation : 

`Numeric-looking arguments will be returned as numbers unless opts.string or opts.boolean contains that argument name. To disable numeric conversion for non-option arguments, add '_' to opts.string.`