### PR TITLE
Changement Buffer Cadastre et ffth

### DIFF
--- a/lib/compose/sources/cadastre.cjs
+++ b/lib/compose/sources/cadastre.cjs
@@ -78,7 +78,7 @@ function extractLieuxDits(adressesCommune) {
 async function prepareData(adressesCommune, {codeCommune}) {
   const context = {adresses: adressesCommune, codeCommune}
 
-  await filterOutOfCommune(context, 0.6)
+  await filterOutOfCommune(context, 0.05)
 
   await updateCommunes(context.adresses)
   await recomputeCodesVoies(context.adresses)

--- a/lib/compose/sources/ftth.cjs
+++ b/lib/compose/sources/ftth.cjs
@@ -6,7 +6,7 @@ const filterOutOfCommune = require('../processors/filter-out-of-commune.cjs')
 async function prepareData(adressesCommune, {codeCommune}) {
   const context = {adresses: adressesCommune, codeCommune}
 
-  await filterOutOfCommune(context, 0.2)
+  await filterOutOfCommune(context, 0.05)
 
   const filteredAdresses = context.adresses.filter(a => {
     // Suppression des pseudo-numéros, approche grossière pour commencer.


### PR DESCRIPTION
Exemple : les données d'assemblage de la commune voisine vienne "polluer" l’affichage de la BAL de Niedermorschwihr https://adresse.data.gouv.fr/base-adresse-nationale/68237_0100#15.61/48.101253/7.236892

Modification du buffer à 50m pour ftth et cadastre

Fix:#423