### PR TITLE
fix: bug validateur profile

### DIFF
--- a/lib/compose/import-from-api-depot.cjs
+++ b/lib/compose/import-from-api-depot.cjs
@@ -10,7 +10,7 @@ const defaultProfile = '1.3-relax'
 async function importFromApiDepot(revision) {
   const revisionFile = await getRevisionFile(revision._id)
 
-  if (profiles[defaultProfile]) {
+  if (!profiles[defaultProfile]) {
     throw new Error('Le profile du validateur n’existe pas')
   }
 

--- a/lib/compose/import-from-api-depot.cjs
+++ b/lib/compose/import-from-api-depot.cjs
@@ -1,15 +1,20 @@
-const {validate} = require('@ban-team/validateur-bal')
+const {validate, profiles} = require('@ban-team/validateur-bal')
 const {getRevisionFile} = require('../util/api-depot.cjs')
 
 function isErroredRow(row) {
   return row.errors.some(({level}) => level === 'E')
 }
 
-const relaxProfile = 'relax'
+const defaultProfile = '1.3-relax'
 
 async function importFromApiDepot(revision) {
   const revisionFile = await getRevisionFile(revision._id)
-  const validationResult = await validate(revisionFile, {profile: relaxProfile})
+
+  if (profiles[defaultProfile]) {
+    throw new Error('Le profile du validateur n’existe pas')
+  }
+
+  const validationResult = await validate(revisionFile, {profile: defaultProfile})
 
   if (!validationResult.parseOk) {
     throw new Error(`Le fichier BAL récupéré n’est pas valide : ${revision._id}`)

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ban-team/fantoir": "^0.15.0",
     "@ban-team/gazetteer": "^3.2.0",
     "@ban-team/shared-data": "^1.2.0",
-    "@ban-team/validateur-bal": "^2.17.0",
+    "@ban-team/validateur-bal": "^2.19.0",
     "@etalab/adresses-util": "^0.8.2",
     "@etalab/decoupage-administratif": "^4.0.0",
     "@etalab/majic": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ban-team/fantoir": "^0.15.0",
     "@ban-team/gazetteer": "^3.2.0",
     "@ban-team/shared-data": "^1.2.0",
-    "@ban-team/validateur-bal": "^2.19.0",
+    "@ban-team/validateur-bal": "^2.19.1",
     "@etalab/adresses-util": "^0.8.2",
     "@etalab/decoupage-administratif": "^4.0.0",
     "@etalab/majic": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,10 +1058,10 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.2.0.tgz#0e29e84a00f7df3b17e5821bde1405a2bfa656b5"
   integrity sha512-35jz6ITHHufUKxXAfa8ReSMl6lZarnfVBkS++wgHpk27e9K52bXyAHo+n3X331n2mSzoIQXxFK7SEcPob7a5cA==
 
-"@ban-team/validateur-bal@^2.17.0":
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.17.0.tgz#a43965db72d3f5cc19dc710d209f1543ac9eef91"
-  integrity sha512-cNCbiVkQ5sCKs4dN6WSxug65F8oceIdiSmnl4OgYZQ4PY3U0xSf05MqfVd6+xXC4pxAZCRvoxtXrhXGJc9f37A==
+"@ban-team/validateur-bal@^2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.19.0.tgz#681ef655077db1486b45426a2ce2930dd034dcc8"
+  integrity sha512-OIl1BE+MULv/L7ALR6PddNXmqkqwqi31W3SvvK/9GQULZjuMraPXPhHIxpraac1UtbcOzqdSAAKUUfNoqqkQFQ==
   dependencies:
     "@ban-team/shared-data" "^1.2.0"
     "@etalab/project-legal" "^0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,10 +1058,10 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.2.0.tgz#0e29e84a00f7df3b17e5821bde1405a2bfa656b5"
   integrity sha512-35jz6ITHHufUKxXAfa8ReSMl6lZarnfVBkS++wgHpk27e9K52bXyAHo+n3X331n2mSzoIQXxFK7SEcPob7a5cA==
 
-"@ban-team/validateur-bal@^2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.19.0.tgz#681ef655077db1486b45426a2ce2930dd034dcc8"
-  integrity sha512-OIl1BE+MULv/L7ALR6PddNXmqkqwqi31W3SvvK/9GQULZjuMraPXPhHIxpraac1UtbcOzqdSAAKUUfNoqqkQFQ==
+"@ban-team/validateur-bal@^2.19.1":
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.19.1.tgz#5cae5a9fcd9aa3d060809ef23a4adcb0b2f481db"
+  integrity sha512-6AjbS/4RQHVxtihPCRd2D66syaH3wxhPDdjodpoOywCdlCUuuCan6v7AG4gmHc5BtaZlTlIFsYQx63gq5DOpjg==
   dependencies:
     "@ban-team/shared-data" "^1.2.0"
     "@etalab/project-legal" "^0.6.0"


### PR DESCRIPTION
## Problème

Le profile du validateur utilisé par ban-plateform `relax` n'existe pas.
Il n'était pas pris en compte dans la version 2.17.0 du validateur si il n'était pas bon.

## Fix

Utilisation du profile `1.3-relax` qui est celui utilisé dans toutes les autres briques