### PR TITLE
Add report mechanism (storing, APIs and report build)

### DIFF
--- a/lib/api/consumers/build-reports.js
+++ b/lib/api/consumers/build-reports.js
@@ -1,0 +1,22 @@
+import mongo from '../../util/mongo.cjs'
+import {formatAndUpdateReports} from '../report/utils.js'
+
+const buildReportsConsumer = async () => {
+  try {
+    console.log('Building reports...')
+    const filters = {
+      status: null,
+      preProcessingStatusKey: 0,
+      'meta.targetedPlateform': 'ban',
+      preProcessingResponse: {$ne: {}}
+    }
+
+    const reportsNotCompletelyBuilt = await mongo.db.collection('processing_reports').find({...filters}).toArray()
+    await formatAndUpdateReports(reportsNotCompletelyBuilt)
+    console.log('Reports built successfully')
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export default buildReportsConsumer

--- a/lib/api/report/routes.js
+++ b/lib/api/report/routes.js
@@ -1,0 +1,102 @@
+import 'dotenv/config.js' // eslint-disable-line import/no-unassigned-import
+import express from 'express'
+import {getDistrict} from '../district/models.js'
+import mongo from '../../util/mongo.cjs'
+import auth from '../../middleware/auth.js'
+import analyticsMiddleware from '../../middleware/analytics.js'
+import {formatAndUpdateReports, formatReportToInsert} from './utils.js'
+
+const app = new express.Router()
+
+app.route('/district/:districtID')
+  .get(auth, analyticsMiddleware, async (req, res) => {
+    let response
+    try {
+      const {districtID} = req.params
+      const reports = await mongo.db.collection('processing_reports')
+        .find({districtID})
+        .sort({preProcessingDate: -1})
+        .toArray()
+      const formattedReports = await formatAndUpdateReports(reports)
+      res.send(formattedReports)
+    } catch (error) {
+      const {message} = error
+      response = {
+        date: new Date(),
+        status: 'error',
+        message,
+        response: {},
+      }
+    }
+
+    res.send(response)
+  })
+
+app.route('/district/cog/:cog')
+  .get(auth, analyticsMiddleware, async (req, res) => {
+    let response
+    try {
+      const {cog} = req.params
+      const reports = await mongo.db.collection('processing_reports')
+        .find({'meta.cog': cog})
+        .sort({preProcessingDate: 1})
+        .toArray()
+      const formattedReports = await formatAndUpdateReports(reports)
+      res.send(formattedReports)
+    } catch (error) {
+      const {message} = error
+      response = {
+        date: new Date(),
+        status: 'error',
+        message,
+        response: {},
+      }
+    }
+
+    res.send(response)
+  })
+
+app.route('/district/:districtID')
+  .post(auth, analyticsMiddleware, async (req, res) => {
+    let response
+    try {
+      const {districtID} = req.params
+      const district = await getDistrict(districtID)
+
+      if (!district) {
+        res.status(404).send('Request ID unknown')
+        return
+      }
+
+      // Count the number of documents with the same districtID
+      const count = await mongo.db.collection('processing_reports').countDocuments({districtID})
+
+      // If the count is 5 or more, delete the oldest document based on preProcessingDate
+      if (count >= 5) {
+        await mongo.db.collection('processing_reports').findOneAndDelete({districtID}, {sort: {preProcessingDate: 1}}).toArray()
+      }
+
+      const report = req.body
+      const formatedReportToInsert = formatReportToInsert(districtID, report)
+
+      await mongo.db.collection('processing_reports').insertOne(formatedReportToInsert, {upsert: true})
+      response = {
+        date: new Date(),
+        status: 'success',
+        message: 'Processing report created successfully',
+        response: {},
+      }
+    } catch (error) {
+      const {message} = error
+      response = {
+        date: new Date(),
+        status: 'error',
+        message,
+        response: {},
+      }
+    }
+
+    res.send(response)
+  })
+
+export default app

--- a/lib/api/report/utils.js
+++ b/lib/api/report/utils.js
@@ -1,0 +1,134 @@
+import {PromisePool} from '@supercharge/promise-pool'
+import mongo from '../../util/mongo.cjs'
+import {getJobStatus} from '../job-status/models.js'
+
+const categories = ['addresses', 'commonToponyms', 'districts']
+const operations = ['add', 'update', 'delete']
+
+// Status key:  0 = success, 1 = error, -1 = unknown
+
+export const formatReportToInsert = (districtID, report) => {
+  const {preProcessingDate, ...rest} = report
+  return {
+    districtID,
+    ...rest,
+    ...(preProcessingDate ? {preProcessingDate: new Date(preProcessingDate)} : {}),
+  }
+}
+
+export const formatAndUpdateReports = async reports => {
+  const {results} = await PromisePool
+    .withConcurrency(10)
+    .for(reports)
+    .process(formatAndUpdateReport)
+  return results
+}
+
+const formatAndUpdateReport = async report => {
+  const {_id, ...reportRest} = report
+  const {status, preProcessingStatusKey, preProcessingResponse, meta: {targetedPlateform}} = reportRest
+  // If the report does not have a final status yet and the pre-processing status is in success, we need to reconstruct.
+  // the flag 'targetedPlateform' is used to determine if the pre-processing data has been sent to the ban APIs or the legacy compose API
+  // Our ban APIs are asynchronous so the preprocessing report need to be reconstructed to get the final status
+  if (!status && preProcessingStatusKey === 0
+      && targetedPlateform === 'ban'
+      && Object.keys(preProcessingResponse).length > 0
+  ) {
+    try {
+      let errorCount = 0
+      let mostRecentDate = new Date(0)
+      const formattedResponse = {}
+
+      for (const category of categories) {
+        for (const operation of operations) {
+          if (!preProcessingResponse[category] || !preProcessingResponse[category][operation]) { // eslint-disable-line max-depth
+            continue
+          }
+
+          formattedResponse[category] ??= {}
+          const jobStatusArr = await Promise.all( // eslint-disable-line no-await-in-loop
+            preProcessingResponse[category][operation].map(async report => {
+              const statusID = report?.response?.statusID
+              if (!statusID) {
+                throw new Error('Missing statusID in pre-processing report response')
+              }
+
+              const jobStatus = await getJobStatus(statusID)
+              if (!jobStatus) {
+                throw new Error(`Job status ${report.response.statusID} not found : either pending or expired`)
+              }
+
+              return jobStatus
+            })
+          )
+
+          formattedResponse[category][operation] = jobStatusArr.reduce((acc, jobStatus) => {
+            const {status, count, report, updatedAt} = jobStatus
+
+            const date = new Date(updatedAt)
+            if (date > mostRecentDate) {
+              mostRecentDate = date
+            }
+
+            if (status === 'error') {
+              errorCount++
+              acc.error = {
+                count: acc.error ? acc.error.count + count : count,
+                report: [...acc.error.report, report],
+              }
+            }
+
+            if (status === 'success') {
+              acc.success = {
+                count: acc.success ? acc.success.count + count : count,
+              }
+            }
+
+            return acc
+          }, {
+            success: {
+              count: 0,
+            },
+            error: {
+              count: 0,
+              report: []
+            },
+          })
+        }
+      }
+
+      const processingReport = {
+        statusKey: errorCount ? 1 : 0,
+        status: errorCount ? 'error' : 'success',
+        message: errorCount ? 'Processed with errors' : 'Processed successfully',
+        response: formattedResponse,
+        date: mostRecentDate
+      }
+
+      // Update the report with the processing report
+      await mongo.db.collection('processing_reports').updateOne({_id}, {$set: {...processingReport}})
+
+      return {
+        ...reportRest,
+        ...processingReport
+      }
+    } catch (error) {
+      const message = `Could not process the report : ${error.message}`
+      console.log(message)
+      const processingReport = {
+        statusKey: -1,
+        status: 'error',
+        message,
+        response: {},
+        date: new Date()
+      }
+
+      return {
+        ...reportRest,
+        ...processingReport
+      }
+    }
+  }
+
+  return reportRest
+}

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -6,6 +6,7 @@ import commonToponymRoutes from './common-toponym/routes.js'
 import districtRoutes from './district/routes.js'
 import statusRoutes from './job-status/routes.js'
 import banIdRoutes from './ban-id/routes.js'
+import reportRoutes from './report/routes.js'
 
 const app = new express.Router()
 
@@ -14,5 +15,6 @@ app.use('/common-toponym', commonToponymRoutes)
 app.use('/district', districtRoutes)
 app.use('/job-status', statusRoutes)
 app.use('/ban-id', banIdRoutes)
+app.use('/report', reportRoutes)
 
 export default app

--- a/lib/jobs/compose-commune.cjs
+++ b/lib/jobs/compose-commune.cjs
@@ -3,18 +3,22 @@ const {getCommune, finishComposition} = require('../models/commune.cjs')
 const composeCommune = require('../compose/index.cjs')
 
 async function handle({data: {codeCommune, compositionAskedAt, ignoreIdConfig}}) {
-  const communeEntry = await getCommune(codeCommune)
+  try {
+    const communeEntry = await getCommune(codeCommune)
 
-  if (!communeEntry.compositionAskedAt || !isEqual(communeEntry.compositionAskedAt, parseISO(compositionAskedAt))) {
-    return
+    if (!communeEntry.compositionAskedAt || !isEqual(communeEntry.compositionAskedAt, parseISO(compositionAskedAt))) {
+      return
+    }
+
+    console.log(`Composition des adresses de la commune ${codeCommune}`)
+
+    await composeCommune(codeCommune, ignoreIdConfig)
+    await finishComposition(codeCommune)
+
+    console.log(`Composition des adresses de la commune ${codeCommune} terminée`)
+  } catch (error) {
+    console.error(`Erreur lors de la composition de la commune ${codeCommune}`, error)
   }
-
-  console.log(`Composition des adresses de la commune ${codeCommune}`)
-
-  await composeCommune(codeCommune, ignoreIdConfig)
-  await finishComposition(codeCommune)
-
-  console.log(`Composition des adresses de la commune ${codeCommune} terminée`)
 }
 
 module.exports = handle

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@etalab/project-legal": "^0.6.0",
     "@keyv/sqlite": "^3.6.5",
     "@mapbox/tilebelt": "^1.0.2",
+    "@supercharge/promise-pool": "^3.2.0",
     "@turf/turf": "^6.5.0",
     "bluebird": "^3.7.2",
     "bull": "^3.29.3",

--- a/worker.js
+++ b/worker.js
@@ -6,6 +6,7 @@ import ms from 'ms'
 import apiConsumer from './lib/api/consumers/api-consumer.js'
 import exportToExploitationDBConsumer from './lib/api/consumers/export-to-exploitation-db-consumer.js'
 import cleanJobStatusConsumer from './lib/api/consumers/clean-job-status-consumer.js'
+import buildReportsConsumer from './lib/api/consumers/build-reports.js'
 
 import mongo from './lib/util/mongo.cjs'
 import queue from './lib/util/queue.cjs'
@@ -36,6 +37,8 @@ async function main() {
   queue('export-to-exploitation-db').process(1, exportToExploitationDBConsumer)
   queue('clean-job-status').process(1, cleanJobStatusConsumer)
   queue('clean-job-status').add({}, {jobId: 'cleanJobStatusJobId', repeat: {every: ms('1d')}, removeOnComplete: true})
+  queue('build-reports').process(1, buildReportsConsumer)
+  queue('build-reports').add({}, {jobId: 'buildReportsJobId', repeat: {every: ms('1d')}, removeOnComplete: true})
 }
 
 main().catch(error => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,6 +1547,11 @@
   dependencies:
     "@sinonjs/commons" "^2.0.0"
 
+"@supercharge/promise-pool@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@supercharge/promise-pool/-/promise-pool-3.2.0.tgz#a6ab4afdf798e453a6bb51c4ae340852e1266af8"
+  integrity sha512-pj0cAALblTZBPtMltWOlZTQSLT07jIaFNeM8TWoJD1cQMgDB9mcMlVMoetiB35OzNJpqQ2b+QEtwiR9f20mADg==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
# Context

Our back-end system is composed of several components : 
- Pre-processing component (id-fix)
- Processing component (ban-plateforme)

Our logs are separated and also are only written on server files. 
Our system need to have a better visibility on the pre-processing and processing logs of the BAL sent to the BAN.

# Enhancements

This PR aims to add : 
- a new "processing-reports" collections to store the reports
- new APIs route to POST and GET the reports stored in the collection (max 5 per district)
- a build mechanism for reports that target asynchronous operations (such our pre-processing component sending data through the BAN APIs).

There are two ways to build an asynchronous report : 
- GET the report (GET `/api/report/district/{districtID}` (or GET `/api/report/district/cog/{cog}`)
- wait for the daily batch (worker job)

# How to test

Need to start ban-plateforme and id-fix, connected locally.
Here is the corresponding id-fix PR : https://github.com/BaseAdresseNationale/id-fix/pull/92

I. Legacy pre-processing report : 
- Send a BAL through id-fix that is not part of the whitelist or that is not using ban-IDs
- The BAL is sent to ban-plateforme legacy API
- A pre-processing report is generated and sent to ban-plateforme
- The report that is generated in the processing-reports collection is the following one : 

```
{
  "districtID": "a950efd3-69e7-41df-b5d8-a47dc660b66e",
  "preProcessingStatusKey": 0,
  "preProcessingStatus": "success",
  "preProcessingMessage": "Redirected to legacy : District id a950efd3-69e7-41df-b5d8-a47dc660b66e (cog: 59183) is not part of the whitelist.",
  "preProcessingResponse": {},
  "meta": {
    "targetedPlateform": "legacy",
    "revision": {...revisionData*},
    "cog": "59183"
  },
  "preProcessingDate": {
    "$date": "2024-06-21T09:39:19.027Z"
  }
}
```

*revisionData being the data from the last revision of api-de-dépôt.

II. Pre-processing reports - Success:
-  Send a BAL throgh id-fix that is part of the whitelist 
- The BAL is processed by id-fix and all the different components (addresses and common toponyms) are sent to BAN BAN-IDs APIs (`/address` `/common-toponym`)
- A pre-processing report is generated and sent to ban-plateforme
- The report that is generated in the processing-reports collection is the following one : 

```
{
  "districtID": "a950efd3-69e7-41df-b5d8-a47dc660b66e",
  "preProcessingStatusKey": 0,
  "preProcessingStatus": "success",
  "preProcessingMessage": "Pre-processed : District id a950efd3-69e7-41df-b5d8-a47dc660b66e (cog: 59183) pre-processed and sent to BAN APIs.",
  "preProcessingResponse": {
    "addresses": {
      "update": [
        {
          "date": "2024-06-21T09:46:32.527Z",
          "status": "success",
          "message": "Check the status of your request : http://localhost:5000/api/job-status/H5BY3S7AF",
          "response": {
            "statusID": "H5BY3S7AF"
          }
        }
      ],
      "delete": [
        {
          "date": "2024-06-21T09:46:32.531Z",
          "status": "success",
          "message": "Check the status of your request : http://localhost:5000/api/job-status/94DX1NB9Q",
          "response": {
            "statusID": "94DX1NB9Q"
          }
        }
      ]
    },
    "commonToponyms": {
      "update": [
        {
          "date": "2024-06-21T09:46:32.524Z",
          "status": "success",
          "message": "Check the status of your request : http://localhost:5000/api/job-status/26DRMPNQ1",
          "response": {
            "statusID": "26DRMPNQ1"
          }
        }
      ],
      "delete": [
        {
          "date": "2024-06-21T09:46:32.534Z",
          "status": "success",
          "message": "Check the status of your request : http://localhost:5000/api/job-status/BDTT4AGXC",
          "response": {
            "statusID": "BDTT4AGXC"
          }
        }
      ]
    }
  },
  "meta": {
    "targetedPlateform": "ban",
    "revision": {...revisionData*},
    "cog": "59183"
  },
  "preProcessingDate": {
    "$date": "2024-06-21T09:46:32.535Z"
  }
}
```

*revisionData being the data from the last revision of api-de-dépôt.

This pre-processing report contains a pre-processing response with the different status ID from our asynchronous ban apis. This pre-processing report can be "rebuilt" in a final state by two mechanisms : 
- make an API call to GET `api/report/district/{districtID}` (or `/api/report/district/cog/{cog}`)
- make the daily batch run by changing the time between two jobs : 
In worker.js file, change 1d to 10s for example : 
`queue('build-reports').add({}, {jobId: 'buildReportsJobId', repeat: {every: ms('10s')}, removeOnComplete: true})`

III. Pre-processing reports - Error:

The pre-processing report can also sent pre-processing errors such as : 
- a missing ID on a BAL line : 

To test this behaviour : 
- Send a BAL that is part of the whitelist, that have ban ids but that has an error on a line (delete an address ID for example).
- The BAL is processed by id-fix and the error is detected
- A pre-processing report is generated and sent to ban-plateforme
- The report that is generated in the processing-reports collection is the following one : 

```
{
  "districtID": "a950efd3-69e7-41df-b5d8-a47dc660b66e",
  "preProcessingStatusKey": 1,
  "preProcessingStatus": "error",
  "preProcessingMessage": "Not Processed : Missing mainTopoID for bal address {\"objectid\":\"61419\",\"cle_interop\":\"59183_3577_00005\",\"commune_insee\":\"59183\",\"commune_nom\":\"Dunkerque\",\"commune_deleguee_insee\":\"59540\",\"commune_deleguee_nom\":\"Saint-Pol-sur-Mer\",\"voie_nom\":\"Square Delvallez\",\"lieudit_complement_nom\":\"\",\"numero\":5,\"suffixe\":\"\",\"position\":\"entrée\",\"x\":653301.9598168375,\"y\":7103868.546534107,\"long\":2.3358292732844284,\"lat\":51.02876869564352,\"cad_parcelles\":[\"591183540AV0192\",\"591183540AV0191\"],\"source\":\"BAN\",\"date_der_maj\":\"2024-01-04T00:00:00.000Z\",\"certification_commune\":false,\"id_ban_adresse\":\"b611de43-6578-4a07-9ac2-0f58d5b8f0ba\",\"id_ban_toponyme\":\"\",\"id_ban_commune\":\"a950efd3-69e7-41df-b5d8-a47dc660b66e\"}",
  "preProcessingResponse": {},
  "meta": {
    "revision": {...revisionData*},
    "cog": "59183"
  },
  "preProcessingDate": {
    "$date": "2024-06-21T10:12:49.077Z"
  }
}
```

*revisionData being the data from the last revision of api-de-dépôt.