### PR TITLE
Fix generated legacyCommonToponymId with sliced sha256 hash

### DIFF
--- a/lib/api/consumers/format-to-legacy-helpers.js
+++ b/lib/api/consumers/format-to-legacy-helpers.js
@@ -113,7 +113,7 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
     legacyCommonToponymId = `${cog}_${pseudoCodeVoieGenerator.getCode(legacyLabelValue, codeAncienneCommune)}`.toLowerCase()
     // If the pseudo code is already used, we generate a new one with a hash from the common toponym id
     if (commonToponymLegacyIDSet.has(legacyCommonToponymId)) {
-      legacyCommonToponymId = `${cog}_${createHmac('sha256', 'ban').update(id).digest('hex').slice(0, 5)}`
+      legacyCommonToponymId = `${cog}_${createHmac('sha256', 'ban').update(id).digest('hex').slice(0, 6)}`
     }
   }
 


### PR DESCRIPTION
Context : there was an error in the code that generates an id with the sha 256 hash method. The code was slicing the hash from index 0 to 5 (taking the first 5 characters) instead of slicing it from index 0 to 6 (taking the first 6 characters). We need a 6 character id.