### PR TITLE
Added cleInterop in bal meta schema

### DIFF
--- a/lib/api/schema.js
+++ b/lib/api/schema.js
@@ -21,7 +21,9 @@ export const balSchema = object({
   dateRevision: string().trim(),
   codeAncienneCommune: string().trim(),
   nomAncienneCommune: string().trim(),
-  isLieuDit: boolean()
+  isLieuDit: boolean(),
+  cleInterop: string().trim(),
+  deprecatedID: string().trim(),
 }).noUnknown()
 
 export const idfixSchema = object({


### PR DESCRIPTION
# Context : 

In legacy compose algorithm, the `cle_interop` (and `deprecatedID` that is a sub-part of the `cle_interop`) BAL data is not taken from the BAL file but re-calculated in ban-palteforme.
In our new data architecture, we want to add the possibility for a district to retrieve the value given in the BAL file ONLY if valid.

# Enhancement : 
This PR aims to add : 
- the `cleInterop` and `deprecatedID` keys in the bal schema.