### PR TITLE
Added script to init district in local environment from production data in main and exploitation DBs

### DIFF
--- a/toolbox.dev/scripts/init-district-cogs-in-db-from-production.js
+++ b/toolbox.dev/scripts/init-district-cogs-in-db-from-production.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-await-in-loop */
+import fetch from 'node-fetch'
+import {init, District, sequelize} from '../../lib/util/sequelize.js'
+import mongo from '../../lib/util/mongo.cjs'
+
+const BAN_API_PRODUCTION_URL = 'https://plateforme.adresse.data.gouv.fr/api'
+
+const main = async () => {
+  await init()
+  await mongo.connect()
+  const cogs = process.argv.slice(2)
+  for (const cog of cogs) {
+    try {
+      const response = await fetch(`${BAN_API_PRODUCTION_URL}/district/cog/${cog}`)
+      if (!response.ok) {
+        const message = await response.text()
+        throw new Error(`Error while fetching district cog ${cog} : ${message}`)
+      }
+
+      const district = (await response.json())?.response?.[0]
+      const formattedDistrictForMainDB = formatDistrictForMainDB(district)
+      const districtID = formattedDistrictForMainDB.id
+      console.log(`District id ${districtID} (cog : ${cog}) fetched from production API`)
+      await District.bulkCreate([formattedDistrictForMainDB], {updateOnDuplicate: ['id']})
+      console.log(`District ${districtID} (cog : ${cog}) created or updated in local main database (postgresql)`)
+      const formattedDistrictForExploitationDB = formatDistrictForExploitationDB(district)
+      await mongo.db.collection('communes').updateOne({codeCommune: cog}, {$set: formattedDistrictForExploitationDB}, {upsert: true})
+      console.log(`District ${districtID} (cog : ${cog}) created or updated in local exploitation database (mongodb)`)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  await mongo.disconnect()
+  await sequelize.close()
+}
+
+const formatDistrictForMainDB = district => {
+  const {isActive, lastRecordDate, ...districtRest} = district
+  districtRest.updateDate = new Date(districtRest.updateDate)
+  districtRest.config = districtRest.config || {}
+  return districtRest
+}
+
+const formatDistrictForExploitationDB = district => (
+  {
+    codeCommune: district.meta.insee.cog,
+    banId: district.id,
+    nomCommune: district.labels.find(label => label.isoCode === 'fra').value || district.labels[0].value,
+  }
+)
+
+main()


### PR DESCRIPTION
# Context

To improve developper experience, we need to easily initialize internal DBs with data.

# Enhancement

This PRs adds a way to initialize main db (postgresql) and exploitation db (mongodb) with data from production with a script that takes as arguments the insee code

Example : 

`node toolbox.dev/script/init-district-cogs-in-db-from-production.js 12345 67890 ` => Will get the district cog `12345` and `67890` data from production and init the data into the local dbs.