### PR TITLE
Prepare compose all generate id on assemblage

### DIFF
--- a/lib/compose/ask-compose-all.cjs
+++ b/lib/compose/ask-compose-all.cjs
@@ -1,23 +1,31 @@
 #!/usr/bin/env node
 /* eslint no-await-in-loop: off */
 require('dotenv').config()
+const argv = require('minimist')(process.argv.slice(2), {string: '_'})
 const mongo = require('../util/mongo.cjs')
 const {askComposition} = require('../models/commune.cjs')
 const {getCommunes} = require('../util/cog.cjs')
 
 async function main() {
+  const force = argv.force || false
+  if (force) {
+    console.info('option "force" activée')
+  }
+
   await mongo.connect()
 
   const codesCommunesBAN = await mongo.db.collection('communes').distinct('codeCommune')
   const currentCodes = new Set(codesCommunesBAN)
 
   const communes = getCommunes().filter(c => currentCodes.has(c.code))
+  console.log(`Communes à composer: ${communes.length}`)
 
   for (const commune of communes) {
-    await askComposition(commune.code, {force: true})
+    await askComposition(commune.code, {force})
   }
 
-  console.log('Composition forcée demandée')
+  console.log('Composition France entière demandée')
+  console.log('Faire un `yarn compose` pour lancer la composition')
   await mongo.disconnect()
   process.exit(0)
 }

--- a/lib/compose/cli.cjs
+++ b/lib/compose/cli.cjs
@@ -12,10 +12,11 @@ async function main() {
 
   // Check if --ignoreIdConfig flag is provided
   const ignoreIdConfig = argv.ignoreIdConfig || false
+  const force = argv.force || false
 
   await runInParallel(
     require.resolve('./worker.cjs'),
-    communes.map(codeCommune => ({codeCommune, ignoreIdConfig})),
+    communes.map(codeCommune => ({codeCommune, force, ignoreIdConfig})),
     {maxWorkerMemory: 3072, maxRetries: 5}
   )
 

--- a/lib/compose/index.cjs
+++ b/lib/compose/index.cjs
@@ -85,6 +85,13 @@ async function composeCommune(codeCommune, ignoreIdConfig) {
 
     const isBAL = Boolean(currentRevision)
 
+    // Si la commune est déjà composée avec un identifiant BAN :
+    // On ne la recompose plus pour ne pas écraser les identifiants BAN existants
+    if (!isBAL && !compositionOptions.force && commune?.banId) {
+      console.log(`${codeCommune} | commune 'assemblage' avec identifiant BAN déjà présent => composition ignorée`)
+      return false
+    }
+
     // La bloc suivant garantit qu'il n'y a pas de retour en arrière.
     // Ne sera plus nécessaire quand l'API de dépôt contiendra 100% des BAL contenues dans la BAN
     if (!isBAL && commune?.typeComposition === 'bal') {

--- a/lib/compose/worker.cjs
+++ b/lib/compose/worker.cjs
@@ -4,9 +4,16 @@ const composeCommune = require('./index.cjs')
 
 async function main(options) {
   await mongo.connect()
-  const {codeCommune, ignoreIdConfig} = options
+  const {codeCommune, force, ignoreIdConfig} = options
 
   console.time(`commune ${codeCommune}`)
+
+  if (force) {
+    await mongo.db.collection('communes').updateOne(
+      {codeCommune},
+      {$set: {compositionOptions: {force: true}}}
+    )
+  }
 
   await composeCommune(codeCommune, ignoreIdConfig)
   await finishComposition(codeCommune)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "import:ftth": "node lib/import/cli.cjs ftth",
     "dist": "node lib/distribute/cli.cjs",
     "compose": "node lib/compose/cli.cjs",
-    "composeAllForce": "node lib/compose/compose-all-force.cjs",
+    "askComposeAll": "node lib/compose/ask-compose-all.cjs",
     "lint": "xo",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "worker": "node worker.js",


### PR DESCRIPTION
This PR adds : 
- a check in the legacy composition to ignore composition on a assemblage that already has a banId
- an option to the "compose" command to be able to force composition
- an option to the "askComposeAll" command to be able ask a composition on all district with a force option