### PR TITLE
Update script to generate locaux stats by commune from MAJIC data

### DIFF
--- a/scripts/build-communes-locaux-adresses.cjs
+++ b/scripts/build-communes-locaux-adresses.cjs
@@ -1,12 +1,21 @@
 #!/usr/bin/env node
 require('dotenv').config()
 
+const fs = require('fs');
+const fsPromises = fs.promises;
 const bluebird = require('bluebird')
 const {chain, compact, snakeCase, mapKeys} = require('lodash')
 const Papa = require('papaparse')
 const {getCommuneData} = require('@etalab/majic')
 const {getCommunes} = require('../lib/util/cog.cjs')
-const {replaceResourceFile} = require('../lib/util/datagouv.cjs')
+function getEnv(name) {
+    let val = process.env[name];
+    if ((val === undefined) || (val === null)) {
+        throw Error("missing env var for " + name);
+    }
+    return val;
+}
+const YEAR_MAJIC = getEnv('YEAR_MAJIC')
 
 const ACCEPTED_CATEGORIES_LOCAUX = new Set([
   'maison',
@@ -68,19 +77,16 @@ async function main() {
 
   const communesLocauxCompact = compact(communesLocaux)
 
-  const datasetId = '5fda75d3084b5fa14f89cd2f'
+  // Update manually https://www.data.gouv.fr/fr/datasets/nombre-de-locaux-adressables-par-communes/
+  // with below files
 
-  await replaceResourceFile(
-    datasetId,
-    '9a4a5188-8142-4c9d-b3e6-f54594848509',
-    'communes-locaux-adresses.json',
+  await fsPromises.writeFile(
+    `communes-locaux-adresses-${year}.json`,
     JSON.stringify(communesLocauxCompact)
   )
 
-  await replaceResourceFile(
-    datasetId,
-    '9854b368-abce-479e-80f1-cfdbedaa0232',
-    'communes-locaux-adresses.csv',
+  await fsPromises.writeFile(
+    `communes-locaux-adresses-${year}.csv`,
     Papa.unparse(communesLocauxCompact.map(c => mapKeys(c, (v, k) => snakeCase(k))))
   )
 }


### PR DESCRIPTION
We remove automatic push to data gouv as it's an yearly update and automatic management may erase previous year data.
It's needed to push data manually but it takes less than 5 min yearly but it's safer.
We added MAJIC_YEAR to set the name of output files (export the environnement variable or set it in .env file with 2024 or another year).
For previous years, if you use the script, before running it, you need to change temporarily the dependency in root package.json @etalab/decoupage-administratif version e.g https://github.com/datagouv/decoupage-administratif?tab=readme-ov-file#mill%C3%A9simes-et-versions-de-package otherwise your stats will not match the official COG list at this time.