### PR TITLE
Calculate commune ancienne export postgres mongo - gazetteer implementation

### DIFF
--- a/lib/api/address/schema.js
+++ b/lib/api/address/schema.js
@@ -25,7 +25,7 @@ export const banAddressSchema = object({
     is: true,
     otherwise: schema => schema.required(),
   }),
-  number: number().positive().integer().when('$isPatch', {
+  number: number().integer().min(0).when('$isPatch', {
     is: true,
     otherwise: schema => schema.required(),
   }),

--- a/lib/api/consumers/export-to-exploitation-db-consumer.js
+++ b/lib/api/consumers/export-to-exploitation-db-consumer.js
@@ -1,10 +1,12 @@
 import {Transaction} from 'sequelize'
+import Bluebird from 'bluebird'
 import {createFantoirCommune} from '@ban-team/fantoir'
 import {findCodePostal} from 'codes-postaux/full.js'
 import mongo from '../../util/mongo.cjs'
 import {sequelize, District, CommonToponym} from '../../util/sequelize.js'
 import {derivePositionProps} from '../../util/geo.cjs'
 import {createPseudoCodeVoieGenerator} from '../../pseudo-codes-voies.cjs'
+import gazetteerPromise from '../../util/gazetteer.cjs'
 
 import {formatCommonToponymDataForLegacy, formatAddressDataForLegacy, formatDistrictDataForLegacy} from './format-to-legacy-helpers.js'
 
@@ -114,6 +116,9 @@ export default async function exportToExploitationDB({data}) {
     // Prepare fantoir finder from cog and fantoir sqlite database
     const fantoirFinder = await createFantoirCommune(cog, {fantoirPath: FANTOIR_PATH, withAnciennesCommunes: true})
 
+    // Prepare gazetteer finder to find the ancienne commune
+    const gazetteerFinder = await gazetteerPromise
+
     // Prepare pseudo code voie generator from cog
     const pseudoCodeVoieGenerator = await createPseudoCodeVoieGenerator(cog)
 
@@ -173,6 +178,7 @@ export default async function exportToExploitationDB({data}) {
           },
           transaction,
         })
+
       await sequelize.query(
         createAddressTempTableQuery(tempAddressTableName),
         {
@@ -182,6 +188,7 @@ export default async function exportToExploitationDB({data}) {
           },
           transaction,
         })
+
       // CommonToponym
       // Count the total number of common toponyms and pages to process
       const commonToponymTempTableCountQueryResult = await sequelize.query(
@@ -190,6 +197,7 @@ export default async function exportToExploitationDB({data}) {
           type: sequelize.QueryTypes.SELECT,
           transaction,
         })
+
       const totalCommonToponymTempTableRecordsResult = Number(commonToponymTempTableCountQueryResult?.[0]?.count)
       const totalCommonToponymPages = Math.ceil(totalCommonToponymTempTableRecordsResult / PAGE_SIZE)
 
@@ -208,7 +216,16 @@ export default async function exportToExploitationDB({data}) {
             })
           // Format the data and calculate the fantoir code, tiles and postal code
           const pageDataWithExtraDataCalculation = pageData.map(commonToponym => calculateExtraDataForCommonToponym(commonToponym, cog, fantoirFinder, commonToponymIDFantoirCodeMap))
-          const formatedPageDataForLegacy = pageDataWithExtraDataCalculation.map(commonToponym => formatCommonToponymDataForLegacy(commonToponym, district, pseudoCodeVoieGenerator, commonToponymLegacyIDCommonToponymIDMap, commonToponymLegacyIDSet))
+          const formatedPageDataForLegacy = await Bluebird.mapSeries(pageDataWithExtraDataCalculation,
+            async commonToponym => formatCommonToponymDataForLegacy(
+              commonToponym,
+              {
+                district,
+                pseudoCodeVoieGenerator,
+                commonToponymLegacyIDCommonToponymIDMap,
+                commonToponymLegacyIDSet,
+                gazetteerFinder
+              }))
 
           // Insert the data in the temp collection
           await tempCommonToponymCollection.insertMany(formatedPageDataForLegacy, {ordered: false})
@@ -218,12 +235,9 @@ export default async function exportToExploitationDB({data}) {
         }
       }
 
-      const commonToponymsExportPromises = []
       for (let pageNumber = 1; pageNumber <= totalCommonToponymPages; pageNumber++) {
-        commonToponymsExportPromises.push(fetchAndExportDataFromCommonToponymPage(pageNumber))
+        await fetchAndExportDataFromCommonToponymPage(pageNumber) // eslint-disable-line no-await-in-loop
       }
-
-      await Promise.all(commonToponymsExportPromises)
 
       // Address
       // Count the total number of addresses and pages to process
@@ -251,20 +265,24 @@ export default async function exportToExploitationDB({data}) {
 
         // Format the data and calculate the fantoir code, tiles and postal code
         const pageDataWithExtraDataCalculation = pageData.map(address => calculateExtraDataForAddress(address, cog, commonToponymIDFantoirCodeMap))
-        const formatedPageDataForLegacy = pageDataWithExtraDataCalculation
-          .map(address => formatAddressDataForLegacy(address, district, commonToponymLegacyIDCommonToponymIDMap, addressLegacyIDSet))
-          .filter(Boolean)
+        const formatedPageDataForLegacy = await Bluebird.mapSeries(pageDataWithExtraDataCalculation,
+          async address => formatAddressDataForLegacy(
+            address,
+            {
+              district,
+              commonToponymLegacyIDCommonToponymIDMap,
+              addressLegacyIDSet,
+              gazetteerFinder
+            }))
 
+        const formatedPageDataForLegacyFiltered = formatedPageDataForLegacy.filter(Boolean)
         // Insert the data in the temp collection
-        tempAddressCollection.insertMany(formatedPageDataForLegacy, {ordered: false})
+        tempAddressCollection.insertMany(formatedPageDataForLegacyFiltered, {ordered: false})
       }
 
-      const addressesExportPromises = []
       for (let pageNumber = 1; pageNumber <= totalAddressPages; pageNumber++) {
-        addressesExportPromises.push(fetchAndExportDataFromAddressPage(pageNumber))
+        await fetchAndExportDataFromAddressPage(pageNumber) // eslint-disable-line no-await-in-loop
       }
-
-      await Promise.all(addressesExportPromises)
 
       // District
       // Count the total number of "lieu-dit" common toponym used for the district legacy format
@@ -297,6 +315,9 @@ export default async function exportToExploitationDB({data}) {
       // Pseudo code voie generator saving data
       await pseudoCodeVoieGenerator.save()
 
+      // Clear the cache of the gazetteer
+      gazetteerFinder.clearCache()
+
       // Drop the old data
       await deleteOldDataFromFinaleCollections(cog)
 
@@ -311,6 +332,7 @@ export default async function exportToExploitationDB({data}) {
     } catch (error) {
       await deleteTempCollections([tempDistrictCollection, tempCommonToponymCollection, tempAddressCollection])
       await deleteTempTables([tempCommonToponymTableName, tempAddressTableName])
+      gazetteerFinder.clearCache()
       throw error
     }
 

--- a/lib/api/consumers/format-to-legacy-helpers.js
+++ b/lib/api/consumers/format-to-legacy-helpers.js
@@ -69,7 +69,7 @@ export const formatDistrictDataForLegacy = async (district, {totalCommonToponymR
   }
 }
 
-export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudoCodeVoieGenerator, commonToponymLegacyIDCommonToponymIDMap, commonToponymLegacyIDSet) => {
+export const formatCommonToponymDataForLegacy = async (commonToponym, {district, pseudoCodeVoieGenerator, commonToponymLegacyIDCommonToponymIDMap, commonToponymLegacyIDSet, gazetteerFinder}) => {
   const {labels: districtLabels, meta: {insee: {cog}}} = district
   const {id, districtID, geometry, labels, meta, updateDate, addressCount, certifiedAddressCount, bbox, addressBbox} = commonToponym
 
@@ -83,8 +83,20 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
   const legacyLabelValue = defaultLabel?.value
   const legacyComplementaryLabels = formatLegacyComplementatyLabels(labels, defaultLabelIsoCode)
 
+  // Geographic data
+  const legacyPosition = {
+    ...geometry,
+    coordinates: [round(geometry?.coordinates?.[0]), round(geometry?.coordinates?.[1])]
+  }
+  const lon = legacyPosition?.coordinates?.[0]
+  const lat = legacyPosition?.coordinates?.[1]
+  const commonToponymBbox = formatBboxForLegacy(bbox)
+  const commonToponymAddressBbox = formatBboxForLegacy(addressBbox)
+
+  // Old district
+  const {codeAncienneCommune, nomAncienneCommune} = await calculateLegacyCommuneAncienne(cog, meta, lon, lat, gazetteerFinder)
+
   // Ids
-  const codeAncienneCommune = meta?.bal?.codeAncienneCommune
   const legacyCommonToponymFantoirId = meta?.dgfip?.fantoir ? `${cog}_${meta?.dgfip?.fantoir}` : null
 
   let legacyCommonToponymId = legacyCommonToponymFantoirId
@@ -103,16 +115,7 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
   // Store all the legacy common toponym id
   commonToponymLegacyIDSet.add(legacyCommonToponymId)
 
-  // Geographic data
-  const legacyPosition = {
-    ...geometry,
-    coordinates: [round(geometry?.coordinates?.[0]), round(geometry?.coordinates?.[1])]
-  }
-  const lon = legacyPosition?.coordinates?.[0]
-  const lat = legacyPosition?.coordinates?.[1]
-  const commonToponymBbox = formatBboxForLegacy(bbox)
-  const commonToponymAddressBbox = formatBboxForLegacy(addressBbox)
-
+  // Check if the common toponym is a lieu-dit
   const isLieuDit = meta?.bal?.isLieuDit
 
   if (isLieuDit) {
@@ -129,7 +132,7 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
       codeCommune: cog,
       nomCommune: districtLegacyLabelValue,
       codeAncienneCommune,
-      nomAncienneCommune: meta?.bal?.nomAncienneCommune,
+      nomAncienneCommune,
       codePostal: meta?.laposte?.codePostal,
       parcelles: meta?.cadastre?.ids || [],
       lon,
@@ -152,7 +155,7 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
     codeCommune: cog,
     nomCommune: districtLegacyLabelValue,
     codeAncienneCommune,
-    nomAncienneCommune: meta?.bal?.nomAncienneCommune,
+    nomAncienneCommune,
     nomVoie: legacyLabelValue,
     nomVoieAlt: legacyComplementaryLabels,
     sourceNomVoie: 'bal',
@@ -170,7 +173,7 @@ export const formatCommonToponymDataForLegacy = (commonToponym, district, pseudo
   }
 }
 
-export const formatAddressDataForLegacy = (address, district, commonToponymLegacyIDCommonToponymIDMap, addressLegacyIDSet) => {
+export const formatAddressDataForLegacy = async (address, {district, commonToponymLegacyIDCommonToponymIDMap, addressLegacyIDSet, gazetteerFinder}) => {
   const {meta: {insee: {cog}}} = district
   const {id, mainCommonToponymID, secondaryCommonToponymIDs, districtID, number, suffix, positions, labels, meta, updateDate, certified, bbox} = address
 
@@ -204,6 +207,9 @@ export const formatAddressDataForLegacy = (address, district, commonToponymLegac
   const banIdSecondaryCommonToponyms = secondaryCommonToponymIDs && secondaryCommonToponymIDs.length > 0 ? secondaryCommonToponymIDs : null
   const legacySuffix = suffix ? suffix : null
 
+  // Old district
+  const {codeAncienneCommune, nomAncienneCommune} = await calculateLegacyCommuneAncienne(cog, meta, lon, lat, gazetteerFinder)
+
   return {
     id: legacyID,
     cleInterop: legacyInteropKey,
@@ -213,8 +219,8 @@ export const formatAddressDataForLegacy = (address, district, commonToponymLegac
     banIdSecondaryCommonToponyms,
     idVoie: legacyCommonToponymId,
     codeCommune: cog,
-    codeAncienneCommune: meta?.bal?.codeAncienneCommune,
-    nomAncienneCommune: meta?.bal?.nomAncienneCommune,
+    codeAncienneCommune,
+    nomAncienneCommune,
     numero: number,
     suffixe: legacySuffix,
     lieuDitComplementNom: legacyLabelValue,
@@ -317,4 +323,29 @@ const getAddressLegacyId = (addressLegacyIDSet, legacyInteropKey, suffix = 0) =>
   }
 
   return `${legacyInteropKey}`
+}
+
+const calculateLegacyCommuneAncienne = async (cog, meta, lon, lat, gazetteerFinder) => {
+  const codeAncienneCommuneFromBal = meta?.bal?.codeAncienneCommune
+  const nomAncienneCommuneFromBal = meta?.bal?.nomAncienneCommune
+  if (codeAncienneCommuneFromBal && nomAncienneCommuneFromBal) {
+    return {codeAncienneCommune: codeAncienneCommuneFromBal, nomAncienneCommune: nomAncienneCommuneFromBal}
+  }
+
+  if (!lon || !lat) {
+    return {}
+  }
+
+  const gazetteerResult = await gazetteerFinder.find({lon, lat})
+
+  if (!gazetteerResult) {
+    return {}
+  }
+
+  const {communeAncienne, commune} = gazetteerResult
+  if (!communeAncienne || commune?.code !== cog) {
+    return {}
+  }
+
+  return {codeAncienneCommune: communeAncienne.code, nomAncienneCommune: communeAncienne.nom}
 }

--- a/lib/compose/processors/update-communes.cjs
+++ b/lib/compose/processors/update-communes.cjs
@@ -1,13 +1,7 @@
 const bluebird = require('bluebird')
-const {createGazetteer} = require('@ban-team/gazetteer')
 const debug = require('debug')('adresse-pipeline')
 const {getCommuneActuelle, getNomCommune} = require('../../util/cog.cjs')
-
-const gPromise = createGazetteer({
-  cacheEnabled: true,
-  cacheSize: 50,
-  dbPath: process.env.GAZETTEER_DB_PATH || 'data/gazetteer.sqlite'
-})
+const gPromise = require('../../util/gazetteer.cjs')
 
 async function updateCommunes(adresses) {
   adresses.forEach(adresse => {

--- a/lib/util/gazetteer.cjs
+++ b/lib/util/gazetteer.cjs
@@ -1,0 +1,9 @@
+const {createGazetteer} = require('@ban-team/gazetteer')
+
+const gazetteerPromise = createGazetteer({
+  cacheEnabled: true,
+  cacheSize: 50,
+  dbPath: process.env.GAZETTEER_DB_PATH || 'data/gazetteer.sqlite'
+})
+
+module.exports = gazetteerPromise


### PR DESCRIPTION
# Context

In our new system architecture, the data of the` ancienne commune` is retrieved from the BAL data (columns `commune_deleguee_insee` and `commune_deleguee_nom`). If the district does not enter this data, we are not currently calculating it (as it was the case in our legacy system). 

# Enchancement

In order to fix this issue, this PR adds the old data calculation for the `ancienne commune` from the `gazetteer` db.