### PR TITLE
Added district config in export to exploitation db

### DIFF
--- a/lib/api/consumers/format-to-legacy-helpers.js
+++ b/lib/api/consumers/format-to-legacy-helpers.js
@@ -14,7 +14,7 @@ const districtsAddressesExtraDataIndex = districtsAddressesExtraData.reduce((acc
 }, {})
 
 export const formatDistrictDataForLegacy = async (district, {totalCommonToponymRecords, totalSpecifCommonToponymRecords, totalAddressRecords, totalAddressCertifiedRecords}) => {
-  const {id, meta, labels} = district
+  const {id, meta, labels, config} = district
   const {insee: {cog}} = meta
 
   // District data from administrative division
@@ -65,12 +65,13 @@ export const formatDistrictDataForLegacy = async (district, {totalCommonToponymR
     idRevision: meta?.bal?.idRevision,
     dateRevision: meta?.bal?.dateRevision,
     composedAt: new Date(),
-    withBanId: true
+    withBanId: true,
+    config
   }
 }
 
 export const formatCommonToponymDataForLegacy = async (commonToponym, {district, pseudoCodeVoieGenerator, commonToponymLegacyIDCommonToponymIDMap, commonToponymLegacyIDSet, gazetteerFinder}) => {
-  const {labels: districtLabels, meta: {insee: {cog}}} = district
+  const {labels: districtLabels, meta: {insee: {cog}}, config} = district
   const {id, districtID, geometry, labels, meta, updateDate, addressCount, certifiedAddressCount, bbox} = commonToponym
 
   // Labels
@@ -141,7 +142,9 @@ export const formatCommonToponymDataForLegacy = async (commonToponym, {district,
       tiles: meta?.geography?.tiles,
       position: legacyPosition,
       displayBBox: commonToponymBbox,
-      dateMAJ: legacyUpdateDate
+      dateMAJ: legacyUpdateDate,
+      withBanId: true,
+      config
     }
   }
 
@@ -168,12 +171,14 @@ export const formatCommonToponymDataForLegacy = async (commonToponym, {district,
     tiles: meta?.geography?.tiles,
     sources: ['bal'],
     nbNumeros: Number.parseInt(addressCount, 10),
-    nbNumerosCertifies: Number.parseInt(certifiedAddressCount, 10)
+    nbNumerosCertifies: Number.parseInt(certifiedAddressCount, 10),
+    withBanId: true,
+    config
   }
 }
 
 export const formatAddressDataForLegacy = async (address, {district, commonToponymLegacyIDCommonToponymIDMap, addressLegacyIDSet, gazetteerFinder}) => {
-  const {meta: {insee: {cog}}} = district
+  const {meta: {insee: {cog}}, config} = district
   const {id, mainCommonToponymID, secondaryCommonToponymIDs, districtID, number, suffix, positions, labels, meta, updateDate, certified, bbox} = address
 
   // Labels
@@ -240,7 +245,9 @@ export const formatAddressDataForLegacy = async (address, {district, commonTopon
     certifie: certified,
     codePostal: meta?.laposte?.codePostal,
     libelleAcheminement: meta?.laposte?.libelleAcheminement,
-    adressesOriginales: [address]
+    adressesOriginales: [address],
+    withBanId: true,
+    config
   }
 }
 

--- a/lib/models/commune.cjs
+++ b/lib/models/commune.cjs
@@ -155,7 +155,8 @@ async function getPopulatedCommune(codeCommune) {
     'typeComposition',
     'displayBBox',
     'idRevision',
-    'dateRevision'
+    'dateRevision',
+    'config',
   ]
 
   const commune = await mongo.db.collection('communes')


### PR DESCRIPTION
# Context

In order to correctly activate the certificate for the district that have activated it, we need to have more information in our exploitation db (mongo), coming from our main db (postgresql).

# Enhancement

this PR adds :
- district `config` on all items transferred from our main db (postgresql) to our exploitation DB (mongodb) : address, common toponym and district in our 
- flag `withBanId` on all items transferred from our main db (postgresql) to our exploitation DB (mongodb) : address, common toponym (it was already exported on district items).

This PR also adds the config district in the field returned by the `lookup`