### PR TITLE
Added case in delta report when department are identical

### DIFF
--- a/lib/api/address/utils.js
+++ b/lib/api/address/utils.js
@@ -101,7 +101,7 @@ export const getDeltaReport = async (addressIDsWithHash, districtID) => {
   const currentCog = await getCogFromDistrictID(districtID)
 
   for (const {id, hash} of addressIDsWithHash) {
-    if (existingAddressesMap.has(id)) {
+    if (existingAddressesMap.has(id)) { // The address is already existing in the db
       const existingAddresseDistrictID = existingAddressesMap.get(id).districtID
       // eslint-disable-next-line no-negated-condition
       if (existingAddresseDistrictID !== districtID) {
@@ -111,11 +111,13 @@ export const getDeltaReport = async (addressIDsWithHash, districtID) => {
 
         const sliceLength = getDepartmentSliceLength(currentCog)
 
-        if (currentCog.slice(0, sliceLength) !== existingCog.slice(0, sliceLength)) {
+        if (currentCog.slice(0, sliceLength) === existingCog.slice(0, sliceLength)) {
+          idsToUpdate.push(id)
+        } else {
           idsUnauthorized.push(id)
           console.log(`Warning: addresse with ID ${id} belongs to a different district (current: ${currentCog}, existing: ${existingCog}). This update will be ignored as it already exists elsewhere.`)
         }
-      } else { // The address is already existing in the db
+      } else {
         const existingAddressIsActive = existingAddressesMap.get(id).isActive
         const existingAddressHash = existingAddressesMap.get(id).hash
         // If the address has a different hash we need to update it

--- a/lib/api/common-toponym/utils.js
+++ b/lib/api/common-toponym/utils.js
@@ -103,7 +103,9 @@ export const getDeltaReport = async (commonToponymIDsWithHash, districtID) => {
         // Departement check
 
         const sliceLength = getDepartmentSliceLength(currentCog)
-        if (currentCog.slice(0, sliceLength) !== existingCog.slice(0, sliceLength)) {
+        if (currentCog.slice(0, sliceLength) === existingCog.slice(0, sliceLength)) {
+          idsToUpdate.push(id)
+        } else {
           idsUnauthorized.push(id)
           console.log(`Warning: Common toponym with ID ${id} belongs to a different district (current: ${currentCog}, existing: ${existingCog}). This addition will be ignored as it already exists elsewhere.`)
         }


### PR DESCRIPTION
Fix : addresses and common toponyms needs to be updated when their district ID is different and they are part of the same department.