### PR TITLE
patch: error 500 /ban/stats if no metrics

### DIFF
--- a/lib/api/legacy-routes.cjs
+++ b/lib/api/legacy-routes.cjs
@@ -427,7 +427,7 @@ app.get(
   '/ban/stats',
   w(async (req, res) => {
     const metric = await Metric.getLastMetric('ban-stats')
-    res.send(metric.value)
+    res.send(metric?.value)
   })
 )
 


### PR DESCRIPTION
## CONTEXT

Il y a un table `metrics` dans mongo qui est vide a l'installation.
La route /ban/stats retourne une 500 si la table `metrics` est vide
Le nouveau front ne charge pas si la route /ban/stats répond une 500