### PR TITLE
ajout default langage bal

### DIFF
--- a/lib/api/district/schema.js
+++ b/lib/api/district/schema.js
@@ -5,7 +5,7 @@ const certificateSchema = object({}).noUnknown()
 
 const configSchema = object({
   certificate: certificateSchema,
-  defaultBalLang: string().trim().length(3)
+  defaultBalLang: string().trim().length(3, 'The defaultBalLang field must be exactly 3 characters long.')
 }).noUnknown()
 
 const inseeSchema = object({

--- a/lib/api/district/schema.js
+++ b/lib/api/district/schema.js
@@ -5,6 +5,7 @@ const certificateSchema = object({}).noUnknown()
 
 const configSchema = object({
   certificate: certificateSchema,
+  defaultBalLang: string().trim().length(3)
 }).noUnknown()
 
 const inseeSchema = object({


### PR DESCRIPTION
Ajout d'une clé `defaultBalLang` dans le champ `config` de la table `district` (Postgres).
Permet de pouvoir accepter les langages autres que `fra` dans le champ `voie_nom`